### PR TITLE
Converts ê-*yin to ê-*yan

### DIFF
--- a/source/PCT/pct01.xml
+++ b/source/PCT/pct01.xml
@@ -469,7 +469,7 @@
 ,
 <w canon="kika-itohtahitin" class="vta" gcat="1s2sTA" prefix="2" preverbs="ka|will" sgloss="take_so" stem="itohtah" suffix="-itin">kik-êtohtahitin</w>
 <w canon="itê" class="ipc" gcat="IPC" sgloss="there" stem="itê">itêh</w>
-<w canon="kita-ôh-pimâtisiyin" class="vai" gcat="2sAIcnj" preverbs="kita|to ôh|thence" sgloss="live" stem="pimâtisi" suffix="-yan">kit-ôh-pimâtisiyin</w>
+<w canon="kita-ôh-pimâtisiyan" class="vai" gcat="2sAIcnj" preverbs="kita|to ôh|thence" sgloss="live" stem="pimâtisi" suffix="-yan">kit-ôh-pimâtisiyin</w>
 .</q>
 <gloss>then a certain man who was very good, was told by the dwellers in the sky, “Now I will take you whence you will have your source of life.”</gloss>
 </seg>

--- a/source/PCT/pct03.xml
+++ b/source/PCT/pct03.xml
@@ -798,7 +798,7 @@
 ,
 <q>
 <w canon="kitatamihin" class="vta" gcat="2s1sTA" prefix="2" sgloss="make_grateful" stem="atamih" suffix="-in">kitatamihin</w>
-<w canon="ê-nitotamâkêstamawiyin" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj" sgloss="make_request_for" stem="nitotamâkêstamaw" suffix="-iyan">ê-ntotamâkêstamawiyin</w>
+<w canon="ê-nitotamâkêstamawiyan" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj" sgloss="make_request_for" stem="nitotamâkêstamaw" suffix="-iyan">ê-ntotamâkêstamawiyan</w>
 <w canon="pimâtisiwin" class="ni" gcat="0sNI" sgloss="life" stem="pimâtisiwin" suffix="0">pimâtisiwin</w>
 !</q>
 <gloss>When the women cease to weep, when one has wept, “Thanks!” they say to her; “I thank you for praying for me for life!”</gloss>

--- a/source/PCT/pct07.xml
+++ b/source/PCT/pct07.xml
@@ -98,7 +98,7 @@
 <q rend="PRE 0 POST1">
 <w canon="osâm" class="ipc" gcat="IPC" sgloss="too_much" stem="osâm">osâm</w>
 <w canon="kikitimâkisin" class="vai" gcat="2sAI" prefix="2" sgloss="be_pitiable" stem="kitimâkisi" suffix="-n">kikitimâkisin</w>
-<w canon="ê-nôhtê-okimâwiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj nôhtê|want_to" sgloss="be_chief" stem="okimâwi" suffix="-yan">êh-nôhtê-okimâwiyin</w>
+<w canon="ê-nôhtê-okimâwiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj nôhtê|want_to" sgloss="be_chief" stem="okimâwi" suffix="-yan">êh-nôhtê-okimâwiyan</w>
 .</q>
 <gloss>Too pitiable is thy plight in thy longing to be a chief.”</gloss>
 </seg>
@@ -171,7 +171,7 @@
 <seg n="3.1">
 <q>
 <w canon="tânitê" class="ipc" gcat="IPC" sgloss="where" stem="tânitê">tântêh</w>
-<w canon="ê-wî-itohtêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj wî|will" sgloss="go" stem="itohtê" suffix="-yan">ê-wîh-tohtêyin</w>
+<w canon="ê-wî-itohtêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj wî|will" sgloss="go" stem="itohtê" suffix="-yan">ê-wîh-tohtêyan</w>
 ?</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
 <w canon="wîstâwa" class="nda" gcat="3oNDAof3s" prefix="3" sgloss="cousin" stem="îstâw" suffix="-a">wîstâwah</w>

--- a/source/PCT/pct07.xml
+++ b/source/PCT/pct07.xml
@@ -89,7 +89,7 @@
 <w canon="kika-miyitin" class="vta" gcat="1s2sTA" prefix="2" preverbs="ka|will" sgloss="give_to" stem="miy" suffix="-itin">kika-miyitin</w>
 ;
 <w canon="kimiyitin" class="vta" gcat="1s2sTA" prefix="2" sgloss="give_to" stem="miy" suffix="-itin">kimiyitin</w>
-<w canon="ta-okimâwiyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="be_chief" stem="okimâwi" suffix="-yan">tah-okimâwiyin</w>
+<w canon="ta-okimâwiyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="be_chief" stem="okimâwi" suffix="-yan">tah-okimâwiyin</w>
 .</q>
 <gloss>Four nights from now I shall give it thee; I shall give thee chieftainship.</gloss>
 </seg>
@@ -466,7 +466,7 @@
 <w canon="mîkiwâhpihk" class="ni" gcat="0locNI" sgloss="lodge" stem="mîkiwâhp" suffix="-ihk">mîkiwâhpihk</w>
 ,
 <w canon="mîkiwâhpihk" class="ni" gcat="0locNI" sgloss="lodge" stem="mîkiwâhp" suffix="-ihk">mîkiwâhpihk</w>
-<w canon="kâ-itâmoyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="flee" stem="itâmo" suffix="-yan">k-êtâmoyin</w>
+<w canon="kâ-itâmoyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="flee" stem="itâmo" suffix="-yan">k-êtâmoyin</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .

--- a/source/PCT/pct13.xml
+++ b/source/PCT/pct13.xml
@@ -616,7 +616,7 @@
 <q rend="PRE 0 POST0">
 <w canon="êkâya" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâya">êkâya</w>
 <w canon="kosta" class="vti" gcat="2sTIimp" sgloss="fear" stem="kost" suffix="-a">kostah</w>
-<w canon="ta-nipahikawiyin" class="vta" gcat="x2sTAcnj" preverbs="ta|FUT" sgloss="kill" stem="nipah" suffix="-ikawiyan">ta-nipahikawiyin</w>
+<w canon="ta-nipahikawiyan" class="vta" gcat="x2sTAcnj" preverbs="ta|FUT" sgloss="kill" stem="nipah" suffix="-ikawiyan">ta-nipahikawiyan</w>
 .</q>
 <gloss>do not fear that you will be slain.</gloss>
 </seg>

--- a/source/PCT/pct14.xml
+++ b/source/PCT/pct14.xml
@@ -301,7 +301,7 @@
 <w canon="ê-kapatêskwêhk" class="vai" gcat="xAIcnj" preverbs="ê|cnj" sgloss="take_food_from_kettle" stem="kapatêskwê" suffix="-hk">êh-kapâtêskwêhk</w>
 ,
 <w canon="ita" class="ipc" gcat="IPC" sgloss="there" stem="ita">itah</w>
-<w canon="kâ-pê-itohtêyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj pê|thence" sgloss="go" stem="itohtê" suffix="-yan">kâ-pê-itohtêyin</w>
+<w canon="kâ-pê-itohtêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj pê|thence" sgloss="go" stem="itohtê" suffix="-yan">kâ-pê-itohtêyan</w>
 !</q>
 <gloss>Then she spoke thus: “Hey, Cherry-Tree, it is not here that food is being served, seeing that you have come here!</gloss>
 </seg>
@@ -421,7 +421,7 @@
 <w canon="kisâkihikwak" class="vta" gcat="3p2sTA" prefix="2" sgloss="love" stem="sâkih" suffix="-ikwak">kisâkihikok</w>
 ,
 <w canon="osâm" class="ipc" gcat="IPC" sgloss="because" stem="osâm">osâm</w>
-<w canon="ê-miyosiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_good" stem="miyosi" suffix="-yan">êh-miyosiyin</w>
+<w canon="ê-miyosiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_good" stem="miyosi" suffix="-yan">êh-miyosiyin</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 <w canon="wîscâsa" class="nda" gcat="3oNDAof3s" prefix="3" sgloss="male_cross_cousin" stem="îscâs" suffix="-a">wîscâsah</w>

--- a/source/PCT/pct14.xml
+++ b/source/PCT/pct14.xml
@@ -314,7 +314,7 @@
 <w canon="mîkiwâhp" class="ni" gcat="0sNI" sgloss="lodge" stem="mîkiwâhp" suffix="0">mîkiwâhp</w>
 ,
 <w canon="êkâ" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâ">êkâ</w>
-<w canon="kâ-isi-pakisâpiyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj isi|thus" sgloss="quit_looking" stem="pakisâpi" suffix="-yan">k-êsi-pakisâpiyin</w>
+<w canon="kâ-isi-pakisâpiyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj isi|thus" sgloss="quit_looking" stem="pakisâpi" suffix="-yan">k-êsi-pakisâpiyin</w>
 ,
 <w canon="iskwêwak" class="na" gcat="3pNA" sgloss="woman" stem="iskwêw" suffix="-ak">iskwêwak</w>
 <w canon="osikâkwaniwâwa" class="ndi" gcat="0pNDIof3p" prefix="3" sgloss="calf" stem="sikâkwan" suffix="-iwâwa">osikâkwaniwâwa</w>
@@ -2105,7 +2105,7 @@
 <seg n="52.4">
 <q rend="PRE 0 POST0">
 <w canon="aspin" class="ipc" gcat="IPC" sgloss="off" stem="aspin">aspin</w>
-<w canon="kâ-miyiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="give_to" stem="miy" suffix="-iyan">kâ-miyiyin</w>
+<w canon="kâ-miyiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="give_to" stem="miy" suffix="-iyan">kâ-miyiyan</w>
 ,
 <w canon="namwâc" class="ipc" gcat="IPC" sgloss="not" stem="namwâc">namwâc</w>
 <w canon="nôh-owîcimosin" class="vai" gcat="1sAI" prefix="1" preverbs="ôh|thence" sgloss="have_sweetheart" stem="owîcimosi" suffix="-n">nôh-ôwîcimosin</w>

--- a/source/PCT/pct15.xml
+++ b/source/PCT/pct15.xml
@@ -1459,7 +1459,7 @@
 <w canon="nitohta" class="vti" gcat="2sTIimp" sgloss="listen_to" stem="nitoht" suffix="-a">nitohtah</w>
 <w canon="piko" class="ipc" gcat="IPC" sgloss="only" stem="piko">pikw</w>
 <w canon="isi" class="ipc" gcat="IPC" sgloss="thus" stem="isi">îsi</w>
-<w canon="ê-itikawiyin" class="vta" gcat="x2sTAcnj" preverbs="ê|cnj" sgloss="say_to" stem="it" suffix="-ikawiyan">êh-itikawiyin</w>
+<w canon="ê-itikawiyan" class="vta" gcat="x2sTAcnj" preverbs="ê|cnj" sgloss="say_to" stem="it" suffix="-ikawiyan">êh-itikawiyin</w>
 ;
 <w canon="ê-ohtêyimikawiyan" class="vta" gcat="x2sTAcnj" preverbs="ê|cnj" sgloss="be_jealous_of" stem="ohtêyim" suffix="-ikawiyan">êh-ohtêyimikawiyan</w>
 ,

--- a/source/PCT/pct17.xml
+++ b/source/PCT/pct17.xml
@@ -1105,7 +1105,7 @@
 <w canon="miywâsin" class="vii" gcat="0sII" sgloss="be_good" stem="miywâsin" suffix="0">miywâsin</w>
 <w canon="ê-tôtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj" sgloss="do_thus" stem="tôt" suffix="-aman">êh-tôtaman</w>
 ,
-<w canon="ê-miyosiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_good" stem="miyosi" suffix="-yan">êh-miyosiyin</w>
+<w canon="ê-miyosiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_good" stem="miyosi" suffix="-yan">êh-miyosiyin</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .

--- a/source/PCT/pct21.xml
+++ b/source/PCT/pct21.xml
@@ -1043,7 +1043,7 @@
 <w canon="oskinîkiw" class="na" gcat="3sNA" sgloss="young_man" stem="oskinîkiw" suffix="0">oskinîkiw</w>
 ,
 <w canon="ôhi" class="dem" gcat="0pDEM" sgloss="this" stem="ôma" suffix="-0p">ôhih</w>
-<w canon="kâ-miyiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="give_to" stem="miy" suffix="-iyan">kâ-miyiyin</w>
+<w canon="kâ-miyiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="give_to" stem="miy" suffix="-iyan">kâ-miyiyan</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .
@@ -1702,7 +1702,7 @@
 <q rend="PRE 0 POST1">
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ômâ</w>
 <w canon="osihtâ" class="vai" gcat="2sAIimp" sgloss="prepare" stem="osîhtâ" suffix="-h">osihtâh</w>
-<w canon="kita-oskotâkâyin" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="have_coat" stem="oskotâkâ" suffix="-yan">kit-ôskotâkayin</w>
+<w canon="kita-oskotâkâyan" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="have_coat" stem="oskotâkâ" suffix="-yan">kit-ôskotâkayin</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .
@@ -1889,7 +1889,7 @@
 <w canon="âhkamêyimo" class="vai" gcat="2sAIimp" sgloss="persevere" stem="âhkamêyimo" suffix="0">âhkamêyimô</w>
 <w canon="êkwa" class="ipc" gcat="IPC" sgloss="then" stem="êkwa">êkwah</w>
 <w canon="tâpwê" class="ipc" gcat="IPC" sgloss="truly" stem="tâpwê">tâpwê</w>
-<w canon="kita-atoskêyin" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="work" stem="atoskê" suffix="-yan">kit-âtoskêyin</w>
+<w canon="kita-atoskêyan" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="work" stem="atoskê" suffix="-yan">kit-âtoskêyin</w>
 ;
 </q>
 <gloss>Take heart and work bravely;</gloss>
@@ -2520,7 +2520,7 @@
 <w canon="misatim" class="na" gcat="3sNA" sgloss="horse" stem="mistatimw" suffix="0">misatim</w>
 ,
 <w canon="wiyâs" class="ni" gcat="0sNI" sgloss="meat" stem="wiyâs" suffix="0">wiyâs</w>
-<w canon="kâ-miyiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="give_to" stem="miy" suffix="-iyan">kâ-miyiyin</w>
+<w canon="kâ-miyiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="give_to" stem="miy" suffix="-iyan">kâ-miyiyan</w>
 .</q>
 <gloss>“Now you asked for one horse for the meat you gave me.</gloss>
 </seg>
@@ -2566,7 +2566,7 @@
 <w canon="ê-otihtamân" class="vti" gcat="1sTIcnj" preverbs="ê|cnj" sgloss="reach" stem="otiht" suffix="-amân">êw-otihtamân</w>
 ,
 <w canon="iyikohk" class="ipc" gcat="IPC" sgloss="so_much" stem="iyikohk">iyikohk</w>
-<w canon="kâ-miyiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="give_to" stem="miy" suffix="-iyan">kâ-miyiyin</w>
+<w canon="kâ-miyiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="give_to" stem="miy" suffix="-iyan">kâ-miyiyan</w>
 <w canon="mîciwin" class="ni" gcat="0sNI" sgloss="food" stem="mîciwin" suffix="0">mîciwin</w>
 <w canon="ahtayak" class="na" gcat="3pNA" sgloss="pelt" stem="ahtay" suffix="-ak">ahtayak</w>
 <w canon="mîna" class="ipc" gcat="IPC" sgloss="also" stem="mîna">mînah</w>

--- a/source/PCT/pct21.xml
+++ b/source/PCT/pct21.xml
@@ -175,7 +175,7 @@
 <seg n="4.2">
 <q rend="PRE 0 POST0">
 <w canon="âhkamêyimo" class="vai" gcat="2sAIimp" sgloss="persevere" stem="âhkamêyimo" suffix="0">âhkamêyimô</w>
-<w canon="ê-atoskêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="work" stem="atoskê" suffix="-yan">êh-atoskêyin</w>
+<w canon="ê-atoskêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="work" stem="atoskê" suffix="-yan">êh-atoskêyin</w>
 .</q>
 <gloss>Take heart and work.</gloss>
 </seg>
@@ -511,7 +511,7 @@
 <q rend="PRE0 POST1">
 <w canon="kitatamihin" class="vta" gcat="2s1sTA" prefix="2" sgloss="make_grateful" stem="atamih" suffix="-in">kitatamihin</w>
 <w canon="ôhi" class="dem" gcat="0pDEM" sgloss="this" stem="ôma" suffix="-0p">ôhi</w>
-<w canon="kâ-pê-miyiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj pê|thence" sgloss="give_to" stem="miy" suffix="-iyan">kâ-pê-miyiyin</w>
+<w canon="kâ-pê-miyiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj pê|thence" sgloss="give_to" stem="miy" suffix="-iyan">kâ-pê-miyiyan</w>
 .</q>
 <gloss>I thank you for having come and given me these things.”</gloss>
 </seg>
@@ -753,7 +753,7 @@
 
 <seg n="27.2">
 <q rend="PRE 0 POST1">
-<w canon="kâ-pê-kiyokêyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj pê|thence" sgloss="visit_people" stem="kiyokê" suffix="-yan">kâ-pê-kiyokêyin</w>
+<w canon="kâ-pê-kiyokêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj pê|thence" sgloss="visit_people" stem="kiyokê" suffix="-yan">kâ-pê-kiyokêyan</w>
 <w canon="kîkway" class="pr" gcat="0sPR" sgloss="something" stem="kîkway">kîkway</w>
 <w canon="êtokê" class="ipc" gcat="IPC" sgloss="I_guess" stem="êtikwê">êtokê</w>
 <w canon="ê-pê-nitawêyihtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj pê|thence" sgloss="want" stem="nitawêyiht" suffix="-aman">ê-pê-nitawêyihtaman</w>
@@ -1850,7 +1850,7 @@
 <seg n="59.4">
 <q rend="PRE0 POST0">
 <w canon="âhkamêyimo" class="vai" gcat="2sAIimp" sgloss="persevere" stem="âhkamêyimo" suffix="0">âhkamêyimoh</w>
-<w canon="ê-atoskêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="work" stem="atoskê" suffix="-yan">êh-atoskêyin</w>
+<w canon="ê-atoskêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="work" stem="atoskê" suffix="-yan">êh-atoskêyin</w>
 .
 </q>
 <gloss>Set bravely to work.</gloss>

--- a/source/PCT/pct28.xml
+++ b/source/PCT/pct28.xml
@@ -185,7 +185,7 @@
 <w canon="â" class="ipc" gcat="IPC" sgloss="ah" stem="â">â</w>
 ,
 <w canon="konita" class="ipc" gcat="IPC" sgloss="in_vain" stem="konita">kontah</w>
-<w canon="ê-osîhtâyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="prepare" stem="osîhtâ" suffix="-yan">êh-osîhtâyin</w>
+<w canon="ê-osîhtâyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="prepare" stem="osîhtâ" suffix="-yan">êh-osîhtâyin</w>
 ,
 <q>
 <w canon="osâm" class="ipc" gcat="IPC" sgloss="because" stem="osâm">osâm</w>

--- a/source/PCT/pct34.xml
+++ b/source/PCT/pct34.xml
@@ -144,7 +144,7 @@
 <w canon="wiya" class="ipc" gcat="IPC" sgloss="WIYA" stem="wiya">wiyah</w>
 <w canon="êkâ" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâ">êkâ</w>
 <w canon="ihtakohk" class="vai" gcat="xAIcnj" sgloss="exist" stem="ihtako" suffix="-hk">ihtakohk</w>
-<w canon="kâ-ocikihkwêyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="have_scarred_face" stem="ocikihkwê" suffix="-yan">k-ôcikihkwêyin</w>
+<w canon="kâ-ocikihkwêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="have_scarred_face" stem="ocikihkwê" suffix="-yan">k-ôcikihkwêyin</w>
 ,
 <w canon="ka-isîhkawin" class="vta" gcat="2s1sTA" preverbs="ka|will" sgloss="bother_thus" stem="isîhkaw" suffix="-in">kah-isîhkawin</w>
 ,</q>

--- a/source/PCT/pct37.xml
+++ b/source/PCT/pct37.xml
@@ -1021,7 +1021,7 @@
 <q>
 <w canon="kaskikwâta" class="vti" gcat="2sTIimp" sgloss="sew" stem="kaskikwât" suffix="-a">kaskikwâtah</w>
 ,
-<w canon="kita-oskotâkâyin" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="have_coat" stem="oskotâkâ" suffix="-yan">kit-ôskotâkayin</w>
+<w canon="kita-oskotâkâyan" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="have_coat" stem="oskotâkâ" suffix="-yan">kit-ôskotâkayin</w>
 ,</q>
 <w canon="ê-itât" class="vta" gcat="3s3oTAcnj" preverbs="ê|cnj" sgloss="say_to" stem="it" suffix="-ât">êh-itêt</w>
 ,
@@ -5304,7 +5304,7 @@
 <w canon="namôya" class="ipc" gcat="IPC" sgloss="not" stem="namôya">namoya</w>
 <w canon="ê-nipahikawiyân" class="vta" gcat="x1sTAcnj" preverbs="ê|cnj" sgloss="kill" stem="nipah" suffix="-ikawiyân">êh-nipahikawiyân</w>
 ,
-<w canon="kâ-wâpamiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="see" stem="wâpam" suffix="-iyan">kâ-wâpamiyin</w>
+<w canon="kâ-wâpamiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="see" stem="wâpam" suffix="-iyan">kâ-wâpamiyan</w>
 ,</q>
 <w canon="ê-itikot" class="vta" gcat="3o3sTAcnj" preverbs="ê|cnj" sgloss="say_to" stem="it" suffix="-ikot">êh-itikot</w>
 .
@@ -5426,7 +5426,7 @@
 <q>
 <w canon="kisîm" class="nda" gcat="3sNDAof2s" prefix="2" sgloss="younger_sib" stem="sîm" suffix="0">kisîm</w>
 <w canon="ta-kaskikwâtam" class="vti" gcat="3sTI" preverbs="ta|FUT" sgloss="sew" stem="kaskikwât" suffix="-am">ta-kaskikwâtam</w>
-<w canon="ta-otâsiyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="have_pants" stem="otâsi" suffix="-yan">t-ôtâsiyin</w>
+<w canon="ta-otâsiyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="have_pants" stem="otâsi" suffix="-yan">t-ôtâsiyin</w>
 ,</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
 .

--- a/source/PCT/pct37.xml
+++ b/source/PCT/pct37.xml
@@ -4990,9 +4990,9 @@
 ,
 <w canon="nikwêmê" class="nda" extra="voc" gcat="3sNDAof1svoc" prefix="1" sgloss="namesake" stem="kwêmês">nikwêmê</w>
 ,
-<w canon="ê-kitimâkisiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_pitiable" stem="kitimâkisi" suffix="-yan">ê-kitimâkisiyin</w>
+<w canon="ê-kitimâkisiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_pitiable" stem="kitimâkisi" suffix="-yan">ê-kitimâkisiyan</w>
 ,
-<w canon="ê-wî-nipiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj wî|will" sgloss="die" stem="nipi" suffix="-yan">ê-wîh-nipiyin</w>
+<w canon="ê-wî-nipiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj wî|will" sgloss="die" stem="nipi" suffix="-yan">ê-wîh-nipiyan</w>
 ,
 <q>
 <w canon="kêhcinâ" class="ipc" gcat="IPC" sgloss="surely" stem="kêhcinâ">kêhcinâ</w>
@@ -5004,7 +5004,7 @@
 <w canon="kêhcinâ" class="ipc" gcat="IPC" sgloss="surely" stem="kêhcinâ">kêhcinâ</w>
 <w canon="nika-môwik" class="vta" gcat="3s1sTA" prefix="1" preverbs="ka|will" sgloss="eat" stem="mow" suffix="-ik">nka-môwik</w>
 ,</q>
-<w canon="ê-itêyimiyin" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj" sgloss="think_thus_of" stem="itêyim" suffix="-iyan">êh-itêyimiyin</w>
+<w canon="ê-itêyimiyan" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj" sgloss="think_thus_of" stem="itêyim" suffix="-iyan">êh-itêyimiyin</w>
 ,
 <q>
 <w canon="nicawâc" class="ipc" gcat="IPC" sgloss="best_to_do" stem="nicawâc">ncawâc</w>

--- a/source/PCT/pct38.xml
+++ b/source/PCT/pct38.xml
@@ -636,7 +636,7 @@
 <w canon="nânitaw" class="ipc" gcat="IPC" sgloss="simply" stem="nânitaw">nântaw</w>
 <w canon="nititêyihtên" class="vti" gcat="1sTI" prefix="1" sgloss="think_of" stem="itêyiht" suffix="-ên">ntêyihtên</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
-<w canon="kâ-tôtawiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="do_thus_to" stem="tôtaw" suffix="-iyan">kâ-tôtawiyin</w>
+<w canon="kâ-tôtawiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="do_thus_to" stem="tôtaw" suffix="-iyan">kâ-tôtawiyan</w>
 ,</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
 .
@@ -751,7 +751,7 @@
 <w canon="nitôtêm" class="nda" gcat="3sNDAof1s" prefix="1" sgloss="kinsman" stem="tôtêm" suffix="0">ntôtêm</w>
 ,
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
-<w canon="kâ-tôtawiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="do_thus_to" stem="tôtaw" suffix="-iyan">kâ-tôtawiyin</w>
+<w canon="kâ-tôtawiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="do_thus_to" stem="tôtaw" suffix="-iyan">kâ-tôtawiyan</w>
 ,</q>
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">itwêw</w>
 ;
@@ -763,7 +763,7 @@
 <w canon="osâm" class="ipc" gcat="IPC" sgloss="because" stem="osâm">osâm</w>
 <w canon="êkwêyâk" class="ipc" gcat="IPC" sgloss="exactly_then" stem="êkwêyâk">êkwêyâk</w>
 <w canon="kiya" class="pr" gcat="2sPR" sgloss="you" stem="kiya">kiya</w>
-<w canon="kâ-tôtawiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="do_thus_to" stem="tôtaw" suffix="-iyan">kâ-tôtawiyin</w>
+<w canon="kâ-tôtawiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="do_thus_to" stem="tôtaw" suffix="-iyan">kâ-tôtawiyan</w>
 .</q>
 <gloss>“You are the first to treat me that way.</gloss>
 </seg>
@@ -1186,7 +1186,7 @@
 <w canon="kika-miyitin" class="vta" gcat="1s2sTA" prefix="2" preverbs="ka|will" sgloss="give_to" stem="miy" suffix="-itin">kika-miyitin</w>
 <w canon="cî" class="ipc" gcat="IPC" sgloss="[?]" stem="cî">cî</w>
 <w canon="ayiwinisa" class="ni" gcat="0pNI" sgloss="clothes" stem="ayiwinis" suffix="-a">ayôwinisah</w>
-<w canon="ta-postayôwinisêyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="put_on_clothes" stem="postayôwinisê" suffix="-yan">ta-postayôwinisêyin</w>
+<w canon="ta-postayôwinisêyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="put_on_clothes" stem="postayôwinisê" suffix="-yan">ta-postayôwinisêyan</w>
 ?</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 <w canon="awa" class="dem" gcat="3sDEM" sgloss="this" stem="awa">awa</w>
@@ -1395,7 +1395,7 @@
 <w canon="kâ-tôtâsk" class="vta" gcat="3s2sTAcnj" preverbs="kâ|cnj" sgloss="do_thus_to" stem="tôtaw" suffix="-isk">kâ-tôtâsk</w>
 <w canon="êkâ" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâ">êkâ</w>
 <w canon="kêkway" class="pr" gcat="0sPR" sgloss="something" stem="kîkway">kêkway</w>
-<w canon="kâ-ôh-kî-nipahtâyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence kî|can" sgloss="kill" stem="nipahtâ" suffix="-yan">k-ô-kih-nipahtâyin</w>
+<w canon="kâ-ôh-kî-nipahtâyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence kî|can" sgloss="kill" stem="nipahtâ" suffix="-yan">k-ô-kih-nipahtâyin</w>
 !</q>
 <w canon="itâw" class="vta" gcat="x3sTA" sgloss="say_to" stem="it" suffix="-âw">itâw</w>
 .
@@ -2247,7 +2247,7 @@
 <w canon="kiya" class="pr" gcat="2sPR" sgloss="you" stem="kiya">kiya</w>
 <w canon="kika-tipêyihtên" class="vti" gcat="2sTI" prefix="2" preverbs="ka|will" sgloss="own" stem="tipêyiht" suffix="-ên">kika-tipêyihtên</w>
 <w canon="êkota" class="ipc" gcat="IPC" sgloss="there" stem="êkota">êkota</w>
-<w canon="ta-takosiniyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="arrive" stem="takosin" suffix="-yan">ta-takosiniyin</w>
+<w canon="ta-takosiniyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="arrive" stem="takosin" suffix="-yan">ta-takosiniyan</w>
 .</q>
 <gloss>But you will be the head man until you arrive yonder.</gloss>
 </seg>
@@ -3484,7 +3484,7 @@
 <w canon="kitisi-kitahamâtin" class="vta" gcat="1s2sTA" prefix="2" preverbs="isi|thus" sgloss="advise_against" stem="kitahamaw" suffix="-itin">kitisi-kitahamâtin</w>
 ,
 <w canon="êkâ" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâ">êkâ</w>
-<w canon="ta-maci-nôcihtâyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="pursue_evil_things" stem="maci-nôcihtâ" suffix="-yan">ta-maci-nôcihtâyin</w>
+<w canon="ta-maci-nôcihtâyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="pursue_evil_things" stem="maci-nôcihtâ" suffix="-yan">ta-maci-nôcihtâyan</w>
 .</q>
 <gloss>And so now I forbid you to exercise any more evil arts.”</gloss>
 </seg>

--- a/source/PCT/pct38.xml
+++ b/source/PCT/pct38.xml
@@ -1050,7 +1050,7 @@
 <w canon="kikî-wâpamitin" class="vta" gcat="1s2sTA" prefix="2" preverbs="kî|PAST" sgloss="see" stem="wâpam" suffix="-itin">kikî-wâpamitin</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
 <w canon="kâ-tâpwêhtaman" class="vti" gcat="2sTIcnj" preverbs="kâ|cnj" sgloss="agree_with" stem="tâpwêht" suffix="-aman">kâ-tâpwêhtaman</w>
-<w canon="ê-pê-itisahokawiyan" class="vta" gcat="x2sTAcnj" preverbs="ê|cnj pê|thence" sgloss="send" stem="itisahw" suffix="-ikawiyan">ê-pê-itisahokawiyin</w>
+<w canon="ê-pê-itisahokawiyan" class="vta" gcat="x2sTAcnj" preverbs="ê|cnj pê|thence" sgloss="send" stem="itisahw" suffix="-ikawiyan">ê-pê-itisahokawiyan</w>
 !</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 ;
@@ -1726,7 +1726,7 @@
 ,
 <w canon="êkosi" class="ipc" gcat="IPC" sgloss="thus" stem="êkosi">êkosî</w>
 <w canon="cî" class="ipc" gcat="IPC" sgloss="[?]" stem="cî">cî</w>
-<w canon="ê-wî-mâcîyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj wî|will" sgloss="hunt" stem="mâcî" suffix="-yan">ê-wih-mâciyin</w>
+<w canon="ê-wî-mâcîyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj wî|will" sgloss="hunt" stem="mâcî" suffix="-yan">ê-wih-mâciyan</w>
 ?</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 <w canon="awa" class="dem" gcat="3sDEM" sgloss="this" stem="awa">awa</w>

--- a/source/PCT/pct39.xml
+++ b/source/PCT/pct39.xml
@@ -1276,7 +1276,7 @@
 <w canon="minahôwin" class="ni" gcat="0sNI" sgloss="game_kill" stem="minahôwin" suffix="0">minahôwin</w>
 <w canon="kiwîhtamâk" class="vta" gcat="3s2sTA" prefix="2" sgloss="tell_about" stem="wîhtamaw" suffix="-ik">kiwîhtamâk</w>
 ,
-<w canon="ta-wahkê-nipahtâyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT wahkê|addicted_to" sgloss="kill" stem="nipahtâ" suffix="-yan">ta-wahkêh-nipahtâyin</w>
+<w canon="ta-wahkê-nipahtâyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT wahkê|addicted_to" sgloss="kill" stem="nipahtâ" suffix="-yan">ta-wahkêh-nipahtâyan</w>
 <w canon="kêkway" class="pr" gcat="0sPR" sgloss="something" stem="kîkway">kêkway</w>
 <w canon="pisiskiwak" class="na" gcat="3pNA" sgloss="animal" stem="pisiskiw" suffix="-ak">pisiskiwak</w>
 .</q>
@@ -1333,7 +1333,7 @@
 <w canon="môswak" class="na" gcat="3pNA" sgloss="moose" stem="môsw" suffix="-ak">môswak</w>
 <w canon="kimiyitin" class="vta" gcat="1s2sTA" prefix="2" sgloss="give_to" stem="miy" suffix="-itin">kimiyitin</w>
 ,
-<w canon="kita-asamiyin" class="vta" gcat="2s1sTAcnj" preverbs="kita|to" sgloss="feed" stem="asam" suffix="-iyan">kit-âsamiyin</w>
+<w canon="kita-asamiyan" class="vta" gcat="2s1sTAcnj" preverbs="kita|to" sgloss="feed" stem="asam" suffix="-iyan">kit-âsamiyin</w>
 ,
 <w canon="êkota" class="ipc" gcat="IPC" sgloss="there" stem="êkota">êkotah</w>
 <w canon="ohci" class="ipc" gcat="IPC" sgloss="thence" stem="ohci">ohci</w>

--- a/source/PCT/pct39.xml
+++ b/source/PCT/pct39.xml
@@ -863,7 +863,7 @@
 <seg n="23.2">
 <q rend="PRE 0 POST0">
 <w canon="kêkway" class="pr" gcat="0sPR" sgloss="something" stem="kîkway">kêkway</w>
-<w canon="ê-sâkihtâyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="love" stem="sâkihtâ" suffix="-yan">ê-sâkihtâyin</w>
+<w canon="ê-sâkihtâyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="love" stem="sâkihtâ" suffix="-yan">ê-sâkihtâyan</w>
 <w canon="niwî-otinên" class="vti" gcat="1sTI" prefix="1" preverbs="wî|will" sgloss="take" stem="otin" suffix="-ên">niwîh-otinên</w>
 .</q>
 <gloss>Now I will take a thing you love.</gloss>
@@ -1228,7 +1228,7 @@
 
 <seg n="33.2">
 <q rend="PRE 0 POST0">
-<w canon="ê-atamihiyin" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj" sgloss="make_grateful" stem="atamih" suffix="-iyan">êh-atamihiyin</w>
+<w canon="ê-atamihiyan" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj" sgloss="make_grateful" stem="atamih" suffix="-iyan">êh-atamihiyin</w>
 ,
 <w canon="nama" class="ipc" gcat="IPC" sgloss="not" stem="nama">nama</w>
 <w canon="wîhkâc" class="ipc" gcat="IPC" sgloss="ever" stem="wîhkâc">wîhkâc</w>

--- a/source/PCT/pct40.xml
+++ b/source/PCT/pct40.xml
@@ -930,7 +930,7 @@
 
 <seg n="26.3">
 <q rend="PRE 0 POST0">
-<w canon="kâ-wîkiyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="live_there" stem="wîki" suffix="-yan">kâ-wîkiyin</w>
+<w canon="kâ-wîkiyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="live_there" stem="wîki" suffix="-yan">kâ-wîkiyan</w>
 <w canon="âstamita" class="ipc" gcat="IPC" sgloss="later" stem="âstamita">âstam-itah</w>
 <w canon="kâ-sakâk" class="vii" gcat="0sIIcnj" preverbs="kâ|cnj" sgloss="be_bush" stem="sakâ" suffix="-k">kâ-sakâk</w>
 ,
@@ -947,7 +947,7 @@
 <q rend="PRE 0 POST0">
 <w canon="êkota" class="ipc" gcat="IPC" sgloss="there" stem="êkota">êkotah</w>
 <w canon="kika-ohtinên" class="vti" gcat="2sTI" prefix="2" preverbs="ka|will" sgloss="take_from_there" stem="ohtin" suffix="-ên">kik-ôhtinên</w>
-<w canon="kita-asamiyin" class="vta" gcat="2s1sTAcnj" preverbs="kita|to" sgloss="feed" stem="asam" suffix="-iyan">kit-âsamiyin</w>
+<w canon="kita-asamiyan" class="vta" gcat="2s1sTAcnj" preverbs="kita|to" sgloss="feed" stem="asam" suffix="-iyan">kit-âsamiyin</w>
 .</q>
 <gloss>From there you will get that with which to feed me.</gloss>
 </seg>

--- a/source/PCT/pct41.xml
+++ b/source/PCT/pct41.xml
@@ -2542,7 +2542,7 @@
 <q rend="PRE 0 POST0">
 <w canon="âta" class="ipc" gcat="IPC" sgloss="although" stem="âta">âtah</w>
 <w canon="nipakwâtên" class="vti" gcat="1sTI" prefix="1" sgloss="hate" stem="pakwât" suffix="-ên">nipakwâtên</w>
-<w canon="ê-tôtâkawiyin" class="vta" gcat="x2sTAcnj" preverbs="ê|cnj" sgloss="do_thus_to" stem="tôtaw" suffix="-ikawiyan">êh-tôtâkawiyin</w>
+<w canon="ê-tôtâkawiyan" class="vta" gcat="x2sTAcnj" preverbs="ê|cnj" sgloss="do_thus_to" stem="tôtaw" suffix="-ikawiyan">êh-tôtâkawiyin</w>
 ,
 <w canon="ê-sâkihitân" class="vta" gcat="1s2sTAcnj" preverbs="ê|cnj" sgloss="love" stem="sâkih" suffix="-itân">ê-sâkihitân</w>
 .</q>
@@ -3841,7 +3841,7 @@
 <w canon="namôya" class="ipc" gcat="IPC" sgloss="not" stem="namôya">namoya</w>
 <w canon="ta-kiskêyihtam" class="vti" gcat="3sTI" preverbs="ta|FUT" sgloss="know" stem="kiskêyiht" suffix="-am">ta-kiskêyihtam</w>
 <w canon="kimanâcimâkan" class="nda" gcat="3sNDAof2s" prefix="2" sgloss="parent_in_law" stem="manâcimâkan" suffix="0">kimanâcimâkan</w>
-<w canon="ê-pimâtisiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live" stem="pimâtisi" suffix="-yan">êh-pimâtisiyin</w>
+<w canon="ê-pimâtisiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live" stem="pimâtisi" suffix="-yan">êh-pimâtisiyin</w>
 ,</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
 .
@@ -6391,7 +6391,7 @@
 <w canon="ê-itwêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="say" stem="itwê" suffix="-yan">êh-itwêyan</w>
 <w canon="nika-tôtên" class="vti" gcat="1sTI" prefix="1" preverbs="ka|will" sgloss="do_thus" stem="tôt" suffix="-ên">nka-tôtên</w>
 ,
-<w canon="ê-pimâcihiyin" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj" sgloss="make_live" stem="pimâcih" suffix="-iyan">êh-pimâcihiyin</w>
+<w canon="ê-pimâcihiyan" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj" sgloss="make_live" stem="pimâcih" suffix="-iyan">êh-pimâcihiyin</w>
 .</q>
 <gloss>Whatever you say I will do, for you have restored me to life.”</gloss>
 </seg>
@@ -6938,7 +6938,7 @@
 <q>
 <w canon="namôya" class="ipc" gcat="IPC" sgloss="not" stem="namôya">namoya</w>
 <w canon="niwîhtamawâwak" class="vta" gcat="1s3pTA" prefix="1" sgloss="tell_about" stem="wîhtamaw" suffix="-âwak">niwîhtamawâwak</w>
-<w canon="ê-pimâtisiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live" stem="pimâtisi" suffix="-yan">êh-pimâtisiyin</w>
+<w canon="ê-pimâtisiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live" stem="pimâtisi" suffix="-yan">êh-pimâtisiyin</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .
@@ -7835,7 +7835,7 @@
 <w canon="itohtêtân" class="vai" gcat="1iAIimp" sgloss="go" stem="itohtê" suffix="-tân">tohtêtân</w>
 <w canon="pita" class="ipc" gcat="IPC" sgloss="first" stem="pitamâ">pitah</w>
 ,
-<w canon="kâ-ôh-pê-wayawiyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence pê|thence" sgloss="go_outside" stem="wayawî" suffix="-yan">k-ôh-pê-wayawiyin</w>
+<w canon="kâ-ôh-pê-wayawiyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence pê|thence" sgloss="go_outside" stem="wayawî" suffix="-yan">k-ôh-pê-wayawiyan</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .
@@ -7965,7 +7965,7 @@
 
 <seg n="227.1">
 <q>
-<w canon="ta-pê-kîwêyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT pê|thence" sgloss="go_home" stem="kîwê" suffix="-yan">ta-pê-kîwêyin</w>
+<w canon="ta-pê-kîwêyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT pê|thence" sgloss="go_home" stem="kîwê" suffix="-yan">ta-pê-kîwêyan</w>
 <w canon="êkwa" class="ipc" gcat="IPC" sgloss="then" stem="êkwa">êkwah</w>
 !</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
@@ -8067,7 +8067,7 @@
 <w canon="nânitaw" class="ipc" gcat="IPC" sgloss="simply" stem="nânitaw">nântaw</w>
 <w canon="kititêyimitin" class="vta" gcat="1s2sTA" prefix="2" sgloss="think_thus_of" stem="itêyim" suffix="-itin">kitêyimitn</w>
 ,
-<w canon="ê-kî-âta-tôtawiyin" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj kî|PAST âta|in_vain" sgloss="do_thus_to" stem="tôtaw" suffix="-iyan">ê-kîh-âtah-tôtawiyin</w>
+<w canon="ê-kî-âta-tôtawiyan" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj kî|PAST âta|in_vain" sgloss="do_thus_to" stem="tôtaw" suffix="-iyan">ê-kîh-âtah-tôtawiyan</w>
 ;</q>
 <gloss>“Oh, my father-in-law, I bear you no grudge at all, even though you did that to me;</gloss>
 </seg>
@@ -8184,7 +8184,7 @@
 ,
 <w canon="kimiywêyihtên" class="vti" gcat="2sTI" prefix="2" sgloss="consider_good" stem="miywêyiht" suffix="-ên">kimiywêyihtên</w>
 <w canon="cî" class="ipc" gcat="IPC" sgloss="[?]" stem="cî">cî</w>
-<w canon="ê-owôhtâwîyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="have_father" stem="owôhtâwiyi" suffix="-yan">êh-oyôhtâwiyin</w>
+<w canon="ê-owôhtâwîyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="have_father" stem="owôhtâwiyi" suffix="-yan">êh-oyôhtâwiyin</w>
 ?</q>
 <gloss>Then, as they went to bed, “My wife,” said that young man, “Tell me, are you glad that you have a father?”</gloss>
 </seg>

--- a/source/PCT/pct41.xml
+++ b/source/PCT/pct41.xml
@@ -933,7 +933,7 @@
 <w canon="nitôtêm" class="nda" gcat="3sNDAof1s" prefix="1" sgloss="kinsman" stem="tôtêm" suffix="0">ntôtêm</w>
 ,
 <w canon="anima" class="dem" gcat="0sDEM" sgloss="that" stem="anima">anima</w>
-<w canon="kâ-kî-isiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj kî|PAST" sgloss="say_to" stem="it" suffix="-iyan">kâ-kîh-isiyin</w>
+<w canon="kâ-kî-isiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj kî|PAST" sgloss="say_to" stem="it" suffix="-iyan">kâ-kîh-isiyan</w>
 <w canon="tipiskohk" class="ipc" gcat="IPC" sgloss="last_night" stem="tipiskohk">tipiskohk</w>
 ,
 <w canon="miywêyihtam" class="vti" gcat="3sTI" sgloss="consider_good" stem="miywêyiht" suffix="-am">miywêyihtam</w>
@@ -1391,7 +1391,7 @@
 ,
 <w canon="âyiman" class="vii" gcat="0sII" sgloss="be_difficult" stem="âyiman" suffix="0">âyiman</w>
 <w canon="itê" class="ipc" gcat="IPC" sgloss="there" stem="itê">itêh</w>
-<w canon="kâ-nahâhkapiyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="live_with_wife" stem="nahâhkapi" suffix="-yan">kâ-nahâhkapiyin</w>
+<w canon="kâ-nahâhkapiyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="live_with_wife" stem="nahâhkapi" suffix="-yan">kâ-nahâhkapiyan</w>
 .</q>
 <gloss>“Oh, my son, it is a dangerous place where you are to stay with your wife's people.</gloss>
 </seg>
@@ -1762,7 +1762,7 @@
 <q rend="PRE 0 POST1">
 <w canon="âyimanohk" class="ipc" gcat="IPC" sgloss="in_difficult_place" stem="âyimanohk">âyimanohk</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
-<w canon="kâ-wîkihkêmoyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="live_with_people" stem="wîkihkêmo" suffix="-yan">kâ-wîkihkêmoyin</w>
+<w canon="kâ-wîkihkêmoyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="live_with_people" stem="wîkihkêmo" suffix="-yan">kâ-wîkihkêmoyan</w>
 ,
 <w canon="ana" class="dem" gcat="3sDEM" sgloss="that" stem="ana">an</w>
 <w canon="ana" class="dem" gcat="3sDEM" sgloss="that" stem="ana">âna</w>
@@ -2529,7 +2529,7 @@
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
 <w canon="nôhtâwiy" class="nda" gcat="3sNDAof1s" prefix="1" sgloss="father" stem="ôhtâwiy" suffix="0">nôhtâwiy</w>
 <w canon="êkâ" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâ">êkâ</w>
-<w canon="ta-asamikawiyin" class="vta" gcat="x2sTAcnj" preverbs="ta|FUT" sgloss="feed" stem="asam" suffix="-ikawiyan">t-âsamikawiyin</w>
+<w canon="ta-asamikawiyan" class="vta" gcat="x2sTAcnj" preverbs="ta|FUT" sgloss="feed" stem="asam" suffix="-ikawiyan">t-âsamikawiyin</w>
 ,
 <w canon="êkosi" class="ipc" gcat="IPC" sgloss="thus" stem="êkosi">êkosi</w>
 <w canon="ê-kostâyâhk" class="vta" gcat="1e3sTAcnj" preverbs="ê|cnj" sgloss="fear" stem="kost" suffix="-âyâhk">ê-kostâyâhk</w>
@@ -2559,7 +2559,7 @@
 <w canon="êkosi" class="ipc" gcat="IPC" sgloss="thus" stem="êkosi">êkos</w>
 <w canon="ê-tôtâhcik" class="vta" gcat="x3pTAcnj" preverbs="ê|cnj" sgloss="do_thus_to" stem="tôtaw" suffix="-ihcik">êh-tôtâhcik</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
-<w canon="kâ-wî-tôtâkawiyin" class="vta" gcat="x2sTAcnj" preverbs="kâ|cnj wî|will" sgloss="do_thus_to" stem="tôtaw" suffix="-ikawiyan">kâ-wîh-tôtâkawiyin</w>
+<w canon="kâ-wî-tôtâkawiyan" class="vta" gcat="x2sTAcnj" preverbs="kâ|cnj wî|will" sgloss="do_thus_to" stem="tôtaw" suffix="-ikawiyan">kâ-wîh-tôtâkawiyan</w>
 ,
 <w canon="ê-nipahâhkatosocik" class="vai" gcat="3pAIcnj" preverbs="ê|cnj" sgloss="starve_to_death" stem="nipahâhkatoso" suffix="-cik">êh-nipahâhkatosocik</w>
 .</q>
@@ -3402,7 +3402,7 @@
 <w canon="kititâhkômâw" class="vta" gcat="2s3sTA" prefix="2" sgloss="be_related_to" stem="itâhkôm" suffix="-âw">kititâhkômâw</w>
 ,
 <w canon="iyikohk" class="ipc" gcat="IPC" sgloss="so_much" stem="iyikohk">iyikohk</w>
-<w canon="kâ-mâtoyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="cry" stem="mâto" suffix="-yan">kâ-mâtôyin</w>
+<w canon="kâ-mâtoyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="cry" stem="mâto" suffix="-yan">kâ-mâtôyan</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .
@@ -3580,7 +3580,7 @@
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
 <w canon="wiya" class="ipc" gcat="IPC" sgloss="WIYA" stem="wiya">wiya</w>
 <w canon="ita" class="ipc" gcat="IPC" sgloss="there" stem="ita">itah</w>
-<w canon="kâ-ôh-pa-pimisiniyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|PAST dupL|L.REDUP" sgloss="lie_extended" stem="pimisin" suffix="-yan">k-ôh-pa-pimisiniyin</w>
+<w canon="kâ-ôh-pa-pimisiniyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|PAST dupL|L.REDUP" sgloss="lie_extended" stem="pimisin" suffix="-yan">k-ôh-pa-pimisiniyin</w>
 ?</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
 .
@@ -5222,7 +5222,7 @@
 <w canon="namôya" class="ipc" gcat="IPC" sgloss="not" stem="namôya">namoya</w>
 <w canon="ta-kî-ispayiw" class="vii" gcat="0sII" preverbs="ta|FUT kî|can" sgloss="happen" stem="ispayi" suffix="-w">ta-kîh-ispayiw</w>
 <w canon="anima" class="dem" gcat="0sDEM" sgloss="that" stem="anima">anima</w>
-<w canon="kâ-isiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="say_to" stem="it" suffix="-iyan">k-êsiyin</w>
+<w canon="kâ-isiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="say_to" stem="it" suffix="-iyan">k-êsiyin</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .

--- a/source/PCT/pct42.xml
+++ b/source/PCT/pct42.xml
@@ -613,7 +613,7 @@
 <seg n="11.2">
 <q rend="PRE 0 POST1">
 <w canon="piko" class="ipc" gcat="IPC" sgloss="only" stem="piko">pikoh</w>
-<w canon="kita-kakwêyâhoyin" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="hurry" stem="kakwêyâho" suffix="-yan">kita-kakwêyâhoyin</w>
+<w canon="kita-kakwêyâhoyan" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="hurry" stem="kakwêyâho" suffix="-yan">kita-kakwêyâhoyan</w>
 <w canon="ta-tapasîyahk" class="vai" gcat="1iAIcnj" preverbs="ta|FUT" sgloss="flee" stem="tapasî" suffix="-yahk">ta-tapasiyahk</w>
 ,</q>
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">itwêw</w>
@@ -3081,7 +3081,7 @@
 <q>
 <w canon="namôya" class="ipc" gcat="IPC" sgloss="not" stem="namôya">namoya</w>
 <w canon="konita" class="ipc" gcat="IPC" sgloss="in_vain" stem="konita">kontah</w>
-<w canon="ta-kî-pîhtokêyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT kî|can" sgloss="enter" stem="pîhtikwê" suffix="-yan">ta-kih-pîhtokêyin</w>
+<w canon="ta-kî-pîhtokêyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT kî|can" sgloss="enter" stem="pîhtikwê" suffix="-yan">ta-kih-pîhtokêyan</w>
 ,</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
 <w canon="ôhi" class="dem" gcat="3oDEM" sgloss="this" stem="awa" suffix="-3o">ôhi</w>
@@ -3095,7 +3095,7 @@
 <w canon="tânitowihk" class="ipc" gcat="IPC" sgloss="in_what_place" stem="tânitowihk">tântôwihk</w>
 <w canon="kiya" class="pr" gcat="2sPR" sgloss="you" stem="kiya">kiya</w>
 <w canon="êkâ" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâ">êkâ</w>
-<w canon="kâ-ôh-kî-nipahikawiyin" class="vta" gcat="x2sTAcnj" preverbs="kâ|cnj ôh|thence kî|can" sgloss="kill" stem="nipah" suffix="-ikawiyan">k-ô-kî-nipahikawiyin</w>
+<w canon="kâ-ôh-kî-nipahikawiyan" class="vta" gcat="x2sTAcnj" preverbs="kâ|cnj ôh|thence kî|can" sgloss="kill" stem="nipah" suffix="-ikawiyan">k-ô-kî-nipahikawiyan</w>
 ?</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
 <w canon="êsa" class="ipc" gcat="IPC" sgloss="reportedly" stem="êsa">êsa</w>

--- a/source/PCT/pct42.xml
+++ b/source/PCT/pct42.xml
@@ -2937,7 +2937,7 @@
 <q>
 <w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="ôta" class="ipc" gcat="IPC" sgloss="here" stem="ôta">ôtah</w>
-<w canon="ê-osîhtâyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="prepare" stem="osîhtâ" suffix="-yan">êw-osîhtâyin</w>
+<w canon="ê-osîhtâyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="prepare" stem="osîhtâ" suffix="-yan">êw-osîhtâyin</w>
 ?</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 <w canon="êsa" class="ipc" gcat="IPC" sgloss="reportedly" stem="êsa">êsah</w>

--- a/source/SSSC/sssc04.xml
+++ b/source/SSSC/sssc04.xml
@@ -527,7 +527,7 @@
 <seg n="20.1">
 <q>
 <w canon="tânisi" class="ipc" gcat="IPC" sgloss="how" stem="tânisi">tânisi</w>
-<w canon="ê-wî-isi-masinahikêhiyan" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj wî|will isi|thus" sgloss="hire" stem="masinahikêh" suffix="-iyan">ê-wîh-isi-masinahikêhiyin</w>
+<w canon="ê-wî-isi-masinahikêhiyan" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj wî|will isi|thus" sgloss="hire" stem="masinahikêh" suffix="-iyan">ê-wîh-isi-masinahikêhiyan</w>
 .</q>
 <gloss>“How do you want to employ me?”</gloss>
 </seg>

--- a/source/SSSC/sssc07.xml
+++ b/source/SSSC/sssc07.xml
@@ -1090,7 +1090,7 @@
 <w canon="nama" class="ipc" gcat="IPC" sgloss="not" stem="nama">nama</w>
 <w canon="nânitaw" class="ipc" gcat="IPC" sgloss="simply" stem="nânitaw">nântaw</w>
 <w canon="ka-kî-ohtinamâson" class="vai" gcat="2sAI" preverbs="ka|will kî|can" sgloss="take_for_self" stem="ohtinamâso" suffix="-n">ka-kîh-ohtinamâson</w>
-<w canon="ta-mîciyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="eat" stem="mîci" suffix="-yan">ta-mîciyin</w>
+<w canon="ta-mîciyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="eat" stem="mîci" suffix="-yan">ta-mîciyan</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 <w canon="ôhi" class="dem" gcat="3oDEM" sgloss="this" stem="awa" suffix="-3o">ôhi</w>

--- a/source/SSSC/sssc07.xml
+++ b/source/SSSC/sssc07.xml
@@ -482,7 +482,7 @@
 <w canon="aspin" class="ipc" gcat="IPC" sgloss="off" stem="aspin">aspin</w>
 ,
 <w canon="kâ-pêhtamân" class="vti" gcat="1sTIcnj" preverbs="kâ|cnj" sgloss="hear" stem="pêht" suffix="-amân">kâ-pêhtamân</w>
-<w canon="ê-nikohtêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="collect_firewood" stem="nikohtê" suffix="-yan">ê-nikohtêyin</w>
+<w canon="ê-nikohtêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="collect_firewood" stem="nikohtê" suffix="-yan">ê-nikohtêyan</w>
 !</q>
 <gloss>“Dear me, little brother, for a long time, ever since four nights ago, I have heard you chopping!”</gloss>
 </seg>
@@ -867,7 +867,7 @@
 <w canon="kâ-ôh-kaskihtâyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence" sgloss="be_able_to_do" stem="kaskihtâ" suffix="-yan">k-ôh-kaskihtâyin</w>
 ,
 <w canon="tahki" class="ipc" gcat="IPC" sgloss="always" stem="tahki">tahkih</w>
-<w canon="ê-nikohtêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="collect_firewood" stem="nikohtê" suffix="-yan">ê-nikohtêyin</w>
+<w canon="ê-nikohtêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="collect_firewood" stem="nikohtê" suffix="-yan">ê-nikohtêyan</w>
 <w canon="tahto-kîsikâw" class="ipc" gcat="IPC" sgloss="every_day" stem="tahto-kîsikâw">tahto-kîsikâw</w>
 ?</q>
 <gloss>“But why is it you accomplish nothing, when you are always a-chopping every day?”</gloss>
@@ -1283,7 +1283,7 @@
 <w canon="sôniyâw" class="na" gcat="3sNA" sgloss="gold" stem="sôniyâw" suffix="0">sôniyâw</w>
 <w canon="kâ-ohtinak" class="vta" gcat="1s3sTAcnj" preverbs="kâ|cnj" sgloss="take_from_there" stem="ohtin" suffix="-ak">k-ôhtinak</w>
 <w canon="kîsta" class="pr" gcat="2sPRc" sgloss="you" stem="kîsta">kîstah</w>
-<w canon="pê-itohtêyin" class="vai" gcat="2sAIcnj" preverbs="pê|thence" sgloss="go" stem="itohtê" suffix="-yan">pêy-itohtêyin</w>
+<w canon="pê-itohtêyan" class="vai" gcat="2sAIcnj" preverbs="pê|thence" sgloss="go" stem="itohtê" suffix="-yan">pêy-itohtêyin</w>
 ,</q>
 <w canon="kika-itâw" class="vta" gcat="2s3sTA" prefix="2" preverbs="ka|will" sgloss="say_to" stem="it" suffix="-âw">kik-êtâw</w>
 .</q>
@@ -1587,7 +1587,7 @@
 <seg n="49.1">
 <q rend="PRE 1 POST0">
 <w canon="tânisi" class="ipc" gcat="IPC" sgloss="how" stem="tânisi">tânisi</w>
-<w canon="kâ-ôh-pê-kîwêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence pê|thence" sgloss="go_home" stem="kîwê" suffix="-yan">k-ôh-pê-kîwêyin</w>
+<w canon="kâ-ôh-pê-kîwêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence pê|thence" sgloss="go_home" stem="kîwê" suffix="-yan">k-ôh-pê-kîwêyan</w>
 <w canon="nama" class="ipc" gcat="IPC" sgloss="not" stem="nama">nama</w>
 <w canon="wîhkâc" class="ipc" gcat="IPC" sgloss="ever" stem="wîhkâc">wîhkâc</w>
 <w canon="nôhtaw" class="ipc" gcat="IPC" sgloss="less" stem="nôhtaw">nôhtaw</w>
@@ -1602,7 +1602,7 @@
 <w canon="nîsosâp" class="ipc" gcat="IPC" sgloss="twelve" stem="nîsosâp">nîsosâp</w>
 <w canon="tipahikan" class="ni" gcat="0sNI" sgloss="measure" stem="tipahikan" suffix="0">tipahikan</w>
 <w canon="mâna" class="ipc" gcat="IPC" sgloss="usually" stem="mâna">mâna</w>
-<w canon="kâ-pê-âpihta-kîsikâw-mîcisoyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj pê|thence" sgloss="eat_lunch" stem="âpihtâ-kîsikani-mîciso" suffix="-yan">kâ-pê-âpihta-kîsikâw-mîcisoyin</w>
+<w canon="kâ-pê-âpihta-kîsikâw-mîcisoyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj pê|thence" sgloss="eat_lunch" stem="âpihtâ-kîsikani-mîciso" suffix="-yan">kâ-pê-âpihta-kîsikâw-mîcisoyan</w>
 .</q>
 <gloss>It is always twelve o'clock that you come home to eat dinner.</gloss>
 </seg>
@@ -1750,7 +1750,7 @@
 <q>
 <w canon="êkwa" class="ipc" gcat="IPC" sgloss="then" stem="êkwa">êkwah</w>
 <w canon="wâh-wîpac" class="ipc" gcat="IPC" sgloss="quite_often" stem="wâh-wîpac">wâh-wîpac</w>
-<w canon="ê-pê-kîwêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj pê|thence" sgloss="go_home" stem="kîwê" suffix="-yan">êh-pê-kîwêyin</w>
+<w canon="ê-pê-kîwêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj pê|thence" sgloss="go_home" stem="kîwê" suffix="-yan">êh-pê-kîwêyan</w>
 !</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
 .

--- a/source/SSSC/sssc10.xml
+++ b/source/SSSC/sssc10.xml
@@ -379,7 +379,7 @@
 <w canon="cî" class="ipc" gcat="IPC" sgloss="[?]" stem="cî">ciw</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">omah</w>
 <w canon="êkosi" class="ipc" gcat="IPC" sgloss="thus" stem="êkosi">êkos</w>
-<w canon="ê-isi-minahoyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj isi|thus" sgloss="kill_game" stem="minaho" suffix="-yan">êy-isi-minahoyin</w>
+<w canon="ê-isi-minahoyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj isi|thus" sgloss="kill_game" stem="minaho" suffix="-yan">êy-isi-minahoyin</w>
 ?</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .

--- a/source/SSSC/sssc11.xml
+++ b/source/SSSC/sssc11.xml
@@ -668,7 +668,7 @@
 <w canon="tânitê" class="ipc" gcat="IPC" sgloss="where" stem="tânitê">tântêh</w>
 <w canon="mâka" class="ipc" gcat="IPC" sgloss="but" stem="mâka">mâk</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ômah</w>
-<w canon="ê-ohtohtêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="come_from" stem="ohtohtê" suffix="-yan">êy-ohtohtêyin</w>
+<w canon="ê-ohtohtêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="come_from" stem="ohtohtê" suffix="-yan">êy-ohtohtêyin</w>
 ?</q>
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">itwêw</w>
 <w canon="awa" class="dem" gcat="3sDEM" sgloss="this" stem="awa">awa</w>

--- a/source/SSSC/sssc11.xml
+++ b/source/SSSC/sssc11.xml
@@ -623,7 +623,7 @@
 <q>
 <w canon="tânêhki" class="ipc" gcat="IPC" sgloss="why" stem="tânêhki">tânikhih</w>
 <w canon="apisîs" class="ipc" gcat="IPC" sgloss="a_little" stem="apisîs">apisîs</w>
-<w canon="kâ-pêtâyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="bring" stem="pêtâ" suffix="-yan">kâ-pêtâyin</w>
+<w canon="kâ-pêtâyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="bring" stem="pêtâ" suffix="-yan">kâ-pêtâyan</w>
 <w canon="wiyâs" class="ni" gcat="0sNI" sgloss="meat" stem="wiyâs" suffix="0">wiyâs</w>
 ?</q>
 <gloss>Thus spoke that woman: “Why do you bring so little meat?”</gloss>

--- a/source/SSSC/sssc12.xml
+++ b/source/SSSC/sssc12.xml
@@ -984,10 +984,10 @@
 !
 <w canon="osâm" class="ipc" gcat="IPC" sgloss="because" stem="osâm">osâm</w>
 <w canon="mistahi" class="ipc" gcat="IPC" sgloss="greatly" stem="mistahi">mistahi</w>
-<w canon="ê-manitôwiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_spirit" stem="manitowi" suffix="-yan">êh-manitôwiyin</w>
+<w canon="ê-manitôwiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_spirit" stem="manitowi" suffix="-yan">êh-manitôwiyin</w>
 ,
 <w canon="êkâ" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâ">êkâ</w>
-<w canon="ê-kî-nipahikawiyin" class="vta" gcat="x2sTAcnj" preverbs="ê|cnj kî|can" sgloss="kill" stem="nipah" suffix="-ikawiyan">êh-kîh-nipahikawiyin</w>
+<w canon="ê-kî-nipahikawiyan" class="vta" gcat="x2sTAcnj" preverbs="ê|cnj kî|can" sgloss="kill" stem="nipah" suffix="-ikawiyan">êh-kîh-nipahikawiyin</w>
 ,</q>
 <w canon="kika-itâwâw" class="vta" gcat="2p3sTA" prefix="2" preverbs="ka|will" sgloss="say_to" stem="it" suffix="-âwâw">kik-êtâwâw</w>
 .</q>

--- a/source/SSSC/sssc13.xml
+++ b/source/SSSC/sssc13.xml
@@ -804,7 +804,7 @@
 <w canon="awâsis" class="na" gcat="3sNA" sgloss="child" stem="awâsis" suffix="0">awâsis</w>
 ,
 <w canon="konita" class="ipc" gcat="IPC" sgloss="in_vain" stem="konita">kontah</w>
-<w canon="kâ-papâmâcihoyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="travel_about" stem="papâmâciho" suffix="-yan">kâ-ppâmâcihoyin</w>
+<w canon="kâ-papâmâcihoyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="travel_about" stem="papâmâciho" suffix="-yan">kâ-ppâmâcihoyan</w>
 ;</q>
 <gloss>For you will bring the children to grief wandering about in this needless way;</gloss>
 </seg>

--- a/source/SSSC/sssc13.xml
+++ b/source/SSSC/sssc13.xml
@@ -371,7 +371,7 @@
 ,
 <q>
 <w canon="tânitê" class="ipc" gcat="IPC" sgloss="where" stem="tânitê">tânt</w>
-<w canon="ê-kî-ayâyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj kî|PAST" sgloss="be" stem="ayâ" suffix="-yan">êh-kîh-ayâyin</w>
+<w canon="ê-kî-ayâyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj kî|PAST" sgloss="be" stem="ayâ" suffix="-yan">êh-kîh-ayâyin</w>
 ?</q>
 <gloss>then, “Where have you been?”</gloss>
 </seg>
@@ -762,7 +762,7 @@
 <seg n="24.1">
 <q>
 <w canon="tânitê" class="ipc" gcat="IPC" sgloss="where" stem="tânitê">tântêh</w>
-<w canon="ê-kî-itohtêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj kî|PAST" sgloss="go" stem="itohtê" suffix="-yan">ê-kîh-tohtêyin</w>
+<w canon="ê-kî-itohtêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj kî|PAST" sgloss="go" stem="itohtê" suffix="-yan">ê-kîh-tohtêyan</w>
 <w canon="mâka" class="ipc" gcat="IPC" sgloss="but" stem="mâka">mâka</w>
 <w canon="mîna" class="ipc" gcat="IPC" sgloss="also" stem="mîna">mînah</w>
 ?</q>

--- a/source/SSSC/sssc15.xml
+++ b/source/SSSC/sssc15.xml
@@ -1099,7 +1099,7 @@
 <w canon="êha" class="ipc" gcat="IPC" sgloss="yes" stem="êha">êhag</w>
 ;
 <w canon="êkâ" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâ">êk</w>
-<w canon="ê-pimâtisiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live" stem="pimâtisi" suffix="-yan">êh-pimâtisiyin</w>
+<w canon="ê-pimâtisiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live" stem="pimâtisi" suffix="-yan">êh-pimâtisiyin</w>
 ,
 <w canon="mâka" class="ipc" gcat="IPC" sgloss="but" stem="mâka">mâka</w>
 <w canon="kâ-ôh-pîkiskwêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence" sgloss="use_words" stem="pîkiskwê" suffix="-yan">k-ôh-pîkiskwêyan</w>

--- a/source/SSSC/sssc18.xml
+++ b/source/SSSC/sssc18.xml
@@ -5951,7 +5951,7 @@
 <w canon="nôhtâwiy" class="nda" gcat="3sNDAof1s" prefix="1" sgloss="father" stem="ôhtâwiy" suffix="0">nôhtâwiy</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôm</w>
 <w canon="ôta" class="ipc" gcat="IPC" sgloss="here" stem="ôta">ôtah</w>
-<w canon="ê-ayâyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be" stem="ayâ" suffix="-yan">êh-ayâyin</w>
+<w canon="ê-ayâyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be" stem="ayâ" suffix="-yan">êh-ayâyin</w>
 ,
 <w canon="nîstâ" class="nda" extra="voc" gcat="3sNDAof1svoc" prefix="1" sgloss="cousin" stem="îstâw">nîstâh</w>
 ,

--- a/source/SSSC/sssc18.xml
+++ b/source/SSSC/sssc18.xml
@@ -4493,7 +4493,7 @@
 <q>
 <w canon="kitâpacihon" class="vai" gcat="2sAI" prefix="2" sgloss="do_self_service" stem="âpaciho" suffix="-n">kitâpacihon</w>
 <w canon="êkâ" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâ">êkâ</w>
-<w canon="kâ-pakwâsiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="hate" stem="pakwât" suffix="-iyan">kâ-pakwâsiyin</w>
+<w canon="kâ-pakwâsiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="hate" stem="pakwât" suffix="-iyan">kâ-pakwâsiyan</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 ;
@@ -4598,7 +4598,7 @@
 <w canon="kika-tihkisên" class="vti" gcat="2sTI" prefix="2" preverbs="ka|will" sgloss="melt_down" stem="tihkis" suffix="-ên">kika-tihkisên</w>
 ,
 <w canon="pimiy" class="ni" gcat="0sNI" sgloss="fat" stem="pimiy" suffix="0">pimiy</w>
-<w canon="kita-osîhtâyin" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="prepare" stem="osîhtâ" suffix="-yan">kit-ôsîhtâyin</w>
+<w canon="kita-osîhtâyan" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="prepare" stem="osîhtâ" suffix="-yan">kit-ôsîhtâyin</w>
 ,
 <w canon="êwako" class="pr" gcat="PR" sgloss="that_one" stem="êwako">êwakô</w>
 <w canon="ohci" class="ipc" gcat="IPC" sgloss="thence" stem="ohci">ohci</w>
@@ -5420,7 +5420,7 @@
 ,
 <w canon="nîtim" class="nda" gcat="3sNDAof1s" prefix="1" sgloss="cousin" stem="îtim" suffix="0">nîtim</w>
 ,
-<w canon="kâ-mâtoyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="cry" stem="mâto" suffix="-yan">kâ-mâtoyin</w>
+<w canon="kâ-mâtoyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="cry" stem="mâto" suffix="-yan">kâ-mâtoyan</w>
 ?
 <w canon="koy-ocêmâh" class="vta" gcat="2s3sTAh" prefix="2" preverbs="oy|L.REDUP" sgloss="kiss" stem="ocêm" suffix="-âh">koy-ocêmâ</w>
 <w canon="mâna" class="ipc" gcat="IPC" sgloss="usually" stem="mâna">mâna</w>

--- a/source/SSSC/sssc20.xml
+++ b/source/SSSC/sssc20.xml
@@ -4035,7 +4035,7 @@
 <w canon="nisîmak" class="nda" gcat="3pNDAof1s" prefix="1" sgloss="younger_sib" stem="sîm" suffix="-ak">nisîmak</w>
 <w canon="êkâ" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâ">êkâ</w>
 <w canon="kwayask" class="ipc" gcat="IPC" sgloss="properly" stem="kwayask">kwayask</w>
-<w canon="ê-isiwêpinamawiyan" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj isi|thus" sgloss="throw_on" stem="wêpinamaw" suffix="-iyan">êh-isiwêpinamawiyin</w>
+<w canon="ê-isi-wêpinamawiyan" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj isi|thus" sgloss="throw_on" stem="wêpinamaw" suffix="-iyan">êh-isiwêpinamawiyin</w>
 !</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .

--- a/source/SSSC/sssc20.xml
+++ b/source/SSSC/sssc20.xml
@@ -2533,7 +2533,7 @@
 <q rend="PRE0 POST1">
 <w canon="âyiman" class="vii" gcat="0sII" sgloss="be_difficult" stem="âyiman" suffix="0">âyiman</w>
 <w canon="nânitaw" class="ipc" gcat="IPC" sgloss="simply" stem="nânitaw">nânitaw</w>
-<w canon="ta-kî-itohtêyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT kî|can" sgloss="go" stem="itohtê" suffix="-yan">ta-kîh-itohtêyin</w>
+<w canon="ta-kî-itohtêyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT kî|can" sgloss="go" stem="itohtê" suffix="-yan">ta-kîh-itohtêyan</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 <w canon="osîma" class="nda" gcat="3oNDAof3s" prefix="3" sgloss="younger_sib" stem="sîm" suffix="-a">osîma</w>
@@ -3321,7 +3321,7 @@
 <w canon="tânitê" class="ipc" gcat="IPC" sgloss="where" stem="tânitê">tântê</w>
 <w canon="kê-pîhcâk" class="vii" gcat="0sIIcnj" preverbs="kê|IC+FUT" sgloss="be_long_distance" stem="pîhcâ" suffix="-k">kê-pîhcâk</w>
 <w canon="askiy" class="ni" gcat="0sNI" sgloss="land" stem="askiy" suffix="0">askiy</w>
-<w canon="ta-itâmoyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="flee" stem="itâmo" suffix="-yan">t-êtâmoyin</w>
+<w canon="ta-itâmoyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="flee" stem="itâmo" suffix="-yan">t-êtâmoyin</w>
 ?
 </q>
 <gloss>“Whereto in all the extent of the earth will you flee?</gloss>
@@ -4246,7 +4246,7 @@
 <w canon="opipikwan" class="ni" gcat="0sNIof3s" prefix="3" sgloss="flute" stem="pipikwan" suffix="0">opipikwan</w>
 <w canon="kâ-nayahtahk" class="vti" gcat="3sTIcnj" preverbs="kâ|cnj" sgloss="carry_on_back" stem="nayaht" suffix="-ahk">kâ-nayahtahk</w>
 ,
-<w canon="kâ-isîhoyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="be_so_dressed" stem="isîho" suffix="-yan">k-êsihoyin</w>
+<w canon="kâ-isîhoyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="be_so_dressed" stem="isîho" suffix="-yan">k-êsihoyin</w>
 !</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .

--- a/source/SSSC/sssc20.xml
+++ b/source/SSSC/sssc20.xml
@@ -4035,7 +4035,7 @@
 <w canon="nisîmak" class="nda" gcat="3pNDAof1s" prefix="1" sgloss="younger_sib" stem="sîm" suffix="-ak">nisîmak</w>
 <w canon="êkâ" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâ">êkâ</w>
 <w canon="kwayask" class="ipc" gcat="IPC" sgloss="properly" stem="kwayask">kwayask</w>
-<w canon="ê-isiwêpinamawiyin" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj isi|thus" sgloss="throw_on" stem="wêpinamaw" suffix="-iyan">êh-isiwêpinamawiyin</w>
+<w canon="ê-isiwêpinamawiyan" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj isi|thus" sgloss="throw_on" stem="wêpinamaw" suffix="-iyan">êh-isiwêpinamawiyin</w>
 !</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .
@@ -4088,7 +4088,7 @@
 <w canon="ê-pimipahtâyân" class="vai" gcat="1sAIcnj" preverbs="ê|cnj" sgloss="run" stem="pimipahtâ" suffix="-yân">êh-pimipahtâyân</w>
 ,
 <w canon="osâm" class="ipc" gcat="IPC" sgloss="too_much" stem="osâm">osâm</w>
-<w canon="ê-kisiwi-cîsihiyin" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj kisiwi|angrily" sgloss="deceive" stem="cîsih" suffix="-iyan">êh-kisiwi-cîsihiyin</w>
+<w canon="ê-kisiwi-cîsihiyan" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj kisiwi|angrily" sgloss="deceive" stem="cîsih" suffix="-iyan">êh-kisiwi-cîsihiyin</w>
 ,
 <w canon="iskwêw" class="na" gcat="3sNA" sgloss="woman" stem="iskwêw" suffix="0">iskwêw</w>
 <w canon="ê-itêyimitân" class="vta" gcat="1s2sTAcnj" preverbs="ê|cnj" sgloss="think_thus_of" stem="itêyim" suffix="-itân">êh-itêyimitân</w>
@@ -4858,7 +4858,7 @@
 <q>
 <w canon="êkosi" class="ipc" gcat="IPC" sgloss="thus" stem="êkosi">êkos</w>
 <w canon="ani" class="ipc" gcat="IPC" sgloss="then" stem="ani">âni</w>
-<w canon="ê-pimâtisiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live" stem="pimâtisi" suffix="-yan">ê-pimâtisiyin</w>
+<w canon="ê-pimâtisiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live" stem="pimâtisi" suffix="-yan">ê-pimâtisiyan</w>
 ,
 <w canon="opipikwan" class="ni" gcat="0sNIof3s" prefix="3" sgloss="flute" stem="pipikwan" suffix="0">opipikwan</w>
 <w canon="kâ-nayahtahk" class="vti" gcat="3sTIcnj" preverbs="kâ|cnj" sgloss="carry_on_back" stem="nayaht" suffix="-ahk">kâ-nayahtahk</w>

--- a/source/SSSC/sssc21.xml
+++ b/source/SSSC/sssc21.xml
@@ -3867,7 +3867,7 @@
 <q>
 <w canon="êkosi" class="ipc" gcat="IPC" sgloss="thus" stem="êkosi">êkos</w>
 <w canon="ani" class="ipc" gcat="IPC" sgloss="then" stem="ani">ânih</w>
-<w canon="ê-pmâtisiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live" stem="pimâtisi" suffix="-yan">ê-pmâtisiyan</w>
+<w canon="ê-pimâtisiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live" stem="pimâtisi" suffix="-yan">ê-pmâtisiyan</w>
 ,
 <w canon="pîsimôwâsis" class="na" gcat="3sNA" sgloss="Sun_Child" stem="pîsimôwâsis" suffix="0">pîsimôwâsis</w>
 !

--- a/source/SSSC/sssc21.xml
+++ b/source/SSSC/sssc21.xml
@@ -1263,7 +1263,7 @@
 <w canon="kî-kiskêyimitân" class="vta" gcat="1s2sTAcnj" preverbs="kî|PAST" sgloss="know" stem="kiskêyim" suffix="-itân">kîh-kiskêyimitân</w>
 ,
 <w canon="ôta" class="ipc" gcat="IPC" sgloss="here" stem="ôta">ôtah</w>
-<w canon="ê-wîkiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live_there" stem="wîki" suffix="-yan">êh-wîkiyin</w>
+<w canon="ê-wîkiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live_there" stem="wîki" suffix="-yan">êh-wîkiyin</w>
 ,
 <w canon="ka-pê-kâh-kiyokâtin" class="vta" gcat="1s2sTA" preverbs="ka|will pê|thence dupH|H.REDUP" sgloss="visit" stem="kiyokaw" suffix="-itin">kah-pêh-kâh-kiyôkâtin</w>
 ,
@@ -2140,7 +2140,7 @@
 <q>
 <w canon="tânitê" class="ipc" gcat="IPC" sgloss="where" stem="tânitê">tântêh</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ômah</w>
-<w canon="ê-ohtohtêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="come_from" stem="ohtohtê" suffix="-yan">êh-ohtohtêyin</w>
+<w canon="ê-ohtohtêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="come_from" stem="ohtohtê" suffix="-yan">êh-ohtohtêyin</w>
 ?</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .
@@ -2294,7 +2294,7 @@
 <w canon="mistahi" class="ipc" gcat="IPC" sgloss="greatly" stem="mistahi">mistah</w>
 <w canon="êcika" class="ipc" gcat="IPC" sgloss="what_is_this" stem="êcika">êcik</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
-<w canon="ê-kitimâkisiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_pitiable" stem="kitimâkisi" suffix="-yan">êh-kitimâkisiyin</w>
+<w canon="ê-kitimâkisiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_pitiable" stem="kitimâkisi" suffix="-yan">êh-kitimâkisiyin</w>
 ,
 <w canon="nôsisê" class="nda" extra="voc" gcat="3sNDAof1svoc" prefix="1" sgloss="grandchild" stem="ôsisim">nôsisê</w>
 !</q>
@@ -3194,7 +3194,7 @@
 
 <seg n="92.2">
 <q rend="PRE 0 POST0">
-<w canon="ê-kitimâkisiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_pitiable" stem="kitimâkisi" suffix="-yan">êh-kitimâkisiyin</w>
+<w canon="ê-kitimâkisiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_pitiable" stem="kitimâkisi" suffix="-yan">êh-kitimâkisiyin</w>
 <w canon="kôh-kitimâkêyimitih" class="vta" gcat="1s2sTAh" prefix="2" preverbs="ôh|thence" sgloss="pity" stem="kitimâkêyim" suffix="-itih">kôh-kitimâkêyimitih</w>
 ,
 <w canon="êkwa" class="ipc" gcat="IPC" sgloss="then" stem="êkwa">êkwah</w>
@@ -3244,7 +3244,7 @@
 <w canon="nikiscikânisa" class="ni" gcat="0pNIof1s" prefix="1" sgloss="garden" stem="kiscikânis" suffix="-a">nikiscikânisah</w>
 <w canon="mîna" class="ipc" gcat="IPC" sgloss="also" stem="mîna">mîna</w>
 <w canon="mistahi" class="ipc" gcat="IPC" sgloss="greatly" stem="mistahi">mistah</w>
-<w canon="ê-misi-wanâcihtâyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="ruin" stem="misiwanâcihtâ" suffix="-yan">ê-misi-wanâcihtâyin</w>
+<w canon="ê-misi-wanâcihtâyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="ruin" stem="misiwanâcihtâ" suffix="-yan">ê-misi-wanâcihtâyan</w>
 ;</q>
 <gloss>You have angered me, even though I felt pitying kindness for you when you did me harm and greatly laid waste my garden-plants;</gloss>
 </seg>
@@ -3274,7 +3274,7 @@
 <q rend="PRE 0 POST1">
 <w canon="kimanâkitimahitin" class="vta" gcat="1s2sTA" prefix="2" preverbs="manâ|avoid" sgloss="be_mean_to" stem="kitimah" suffix="-itin">kimanâkitimahitin</w>
 ,
-<w canon="ê-kitimâkisiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_pitiable" stem="kitimâkisi" suffix="-yan">êh-kitimâkisiyin</w>
+<w canon="ê-kitimâkisiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_pitiable" stem="kitimâkisi" suffix="-yan">êh-kitimâkisiyin</w>
 ,</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
 .
@@ -3867,7 +3867,7 @@
 <q>
 <w canon="êkosi" class="ipc" gcat="IPC" sgloss="thus" stem="êkosi">êkos</w>
 <w canon="ani" class="ipc" gcat="IPC" sgloss="then" stem="ani">ânih</w>
-<w canon="ê-pmâtisiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live" stem="pimâtisi" suffix="-yan">ê-pmâtisiyin</w>
+<w canon="ê-pmâtisiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live" stem="pimâtisi" suffix="-yan">ê-pmâtisiyan</w>
 ,
 <w canon="pîsimôwâsis" class="na" gcat="3sNA" sgloss="Sun_Child" stem="pîsimôwâsis" suffix="0">pîsimôwâsis</w>
 !

--- a/source/SSSC/sssc21.xml
+++ b/source/SSSC/sssc21.xml
@@ -1346,7 +1346,7 @@
 
 <seg n="39.1">
 <q rend="PRE 1 POST0">
-<w canon="kâ-ayisiyinîwiyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="be_person" stem="ayisiyinîwi" suffix="-yan">k-âyisiyinîwiyin</w>
+<w canon="kâ-ayisiyinîwiyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="be_person" stem="ayisiyinîwi" suffix="-yan">k-âyisiyinîwiyin</w>
 ,
 <q>
 <w canon="pîsim" class="na" gcat="3sNA" sgloss="sun" stem="pîsimw" suffix="0">pîsim</w>
@@ -1586,7 +1586,7 @@
 <w canon="ka-âpihkonên" class="vti" gcat="2sTI" preverbs="ka|will" sgloss="untie" stem="âpihkon" suffix="-ên">k-âpihkonên</w>
 <w canon="anima" class="dem" gcat="0sDEM" sgloss="that" stem="anima">anim</w>
 <w canon="ita" class="ipc" gcat="IPC" sgloss="there" stem="ita">itah</w>
-<w canon="kâ-wî-pôsiyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj wî|will" sgloss="board" stem="pôsi" suffix="-yan">kâ-wîh-pôsiyin</w>
+<w canon="kâ-wî-pôsiyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj wî|will" sgloss="board" stem="pôsi" suffix="-yan">kâ-wîh-pôsiyan</w>
 .</q>
 <gloss>“Then when you reach yon earth of yours, you will unti that in which you will be riding.</gloss>
 </seg>
@@ -2173,7 +2173,7 @@
 ,
 <w canon="ôhi" class="dem" gcat="0pDEM" sgloss="this" stem="ôma" suffix="-0p">ôhi</w>
 <w canon="nikiscikânisa" class="ni" gcat="0pNIof1s" prefix="1" sgloss="garden" stem="kiscikânis" suffix="-a">nikiscikânisah</w>
-<w canon="kâ-misi-wanâcihtâyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="ruin" stem="misiwanâcihtâ" suffix="-yan">kâ-misi-wanâcihtâyin</w>
+<w canon="kâ-misi-wanâcihtâyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="ruin" stem="misiwanâcihtâ" suffix="-yan">kâ-misi-wanâcihtâyan</w>
 .</q>
 <gloss>“My dear little grandchild, I am not angry at you for having spoiled these plants of mine.</gloss>
 </seg>
@@ -3239,7 +3239,7 @@
 <w canon="ê-âta-kitimâkêyimitân" class="vta" gcat="1s2sTAcnj" preverbs="ê|cnj âta|in_vain" sgloss="pity" stem="kitimâkêyim" suffix="-itân">êh-âta-kitimâkêyimitân</w>
 ,
 <w canon="iyikohk" class="ipc" gcat="IPC" sgloss="so_much" stem="iyikohk">iyikohk</w>
-<w canon="kâ-kîsinâcihiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="make_grieve" stem="kîsinâcih" suffix="-iyan">kâ-kîsinâcihiyin</w>
+<w canon="kâ-kîsinâcihiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="make_grieve" stem="kîsinâcih" suffix="-iyan">kâ-kîsinâcihiyan</w>
 ,
 <w canon="nikiscikânisa" class="ni" gcat="0pNIof1s" prefix="1" sgloss="garden" stem="kiscikânis" suffix="-a">nikiscikânisah</w>
 <w canon="mîna" class="ipc" gcat="IPC" sgloss="also" stem="mîna">mîna</w>
@@ -3763,7 +3763,7 @@
 <w canon="pîsimôwâsis" class="na" gcat="3sNA" sgloss="Sun_Child" stem="pîsimôwâsis" suffix="0">pîsimôwâsis</w>
 ,
 <w canon="mitoni" class="ipc" gcat="IPC" sgloss="intensively" stem="mitoni">mitoni</w>
-<w canon="kâ-kitimahiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="be_mean_to" stem="kitimah" suffix="-iyan">kâ-kitimahiyin</w>
+<w canon="kâ-kitimahiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="be_mean_to" stem="kitimah" suffix="-iyan">kâ-kitimahiyan</w>
 ,
 <w canon="nitawâsimisak" class="na" extra="im" gcat="3pNAof1s" prefix="1" sgloss="child" stem="awâsis" suffix="-ak">nitawâsimisak</w>
 <w canon="êkwa" class="ipc" gcat="IPC" sgloss="then" stem="êkwa">êkwah</w>
@@ -4121,7 +4121,7 @@
 <w canon="âyiman" class="vii" gcat="0sII" sgloss="be_difficult" stem="âyiman" suffix="0">âyiman</w>
 <w canon="ani" class="ipc" gcat="IPC" sgloss="then" stem="ani">ani</w>
 <w canon="ita" class="ipc" gcat="IPC" sgloss="there" stem="ita">itah</w>
-<w canon="kâ-takohtêyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="arrive" stem="takohtê" suffix="-yan">kâ-takohtêyin</w>
+<w canon="kâ-takohtêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="arrive" stem="takohtê" suffix="-yan">kâ-takohtêyan</w>
 <w canon="pisisik" class="ipc" gcat="IPC" sgloss="always" stem="pisisik">pisisik</w>
 <w canon="ê-mêtawêhk" class="vai" gcat="xAIcnj" preverbs="ê|cnj" sgloss="play" stem="mêtawê" suffix="-hk">êh-mêtawêhk</w>
 ,
@@ -5346,9 +5346,9 @@
 <w canon="awiyak" class="pr" gcat="3sPR" sgloss="someone" stem="awiyak">awiyak</w>
 <w canon="kâ-ôh-kakêskimisk" class="vta" gcat="3s2sTAcnj" preverbs="kâ|cnj ôh|thence" sgloss="counsel" stem="kakêskim" suffix="-isk">k-ôh-kakêskimisk</w>
 ,
-<w canon="kâ-papâ-misi-wanâtahkamikisiyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj papâ|around" sgloss="make_mess_of_things" stem="misiwanâtahkamikisi" suffix="-yan">kâ-papâ-misi-wanâtahkamikisiyin</w>
+<w canon="kâ-papâ-misi-wanâtahkamikisiyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj papâ|around" sgloss="make_mess_of_things" stem="misiwanâtahkamikisi" suffix="-yan">kâ-papâ-misi-wanâtahkamikisiyan</w>
 ,
-<w canon="kâ-ôh-kakêpâtisiyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence" sgloss="be_foolish" stem="kakêpâtisi" suffix="-yan">k-ôh-kakêpâtisiyin</w>
+<w canon="kâ-ôh-kakêpâtisiyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence" sgloss="be_foolish" stem="kakêpâtisi" suffix="-yan">k-ôh-kakêpâtisiyin</w>
 .
 </q>
 <gloss>No wonder, seeing how foolish was your mother who took you away with her, so that there was no one to instruct you, no wonder that you went about making a ruin of things at large, and that you are a fool.</gloss>

--- a/source/SSSC/sssc22.xml
+++ b/source/SSSC/sssc22.xml
@@ -1708,7 +1708,7 @@
 <w canon="êyahâ" class="interj" gcat="INTERJ" sgloss="oho" stem="êyahâ">êyahâ</w>
 !
 <w canon="tânisi" class="ipc" gcat="IPC" sgloss="how" stem="tânisi">tânisih</w>
-<w canon="kâ-ôh-pêtôwatâmikawiyan" class="vta" gcat="x2sTAcnj" preverbs="kâ|cnj ôh|thence" sgloss="make_bring_a_load" stem="pêtôwatâm" suffix="-ikawiyan">k-ôh-pêtôwatâmikawiyin</w>
+<w canon="kâ-oh-pêtôwatâmikawiyan" class="vta" gcat="x2sTAcnj" preverbs="kâ|cnj ôh|thence" sgloss="make_bring_a_load" stem="pêtôwatâm" suffix="-ikawiyan">k-ôh-pêtôwatâmikawiyin</w>
 ,
 <w canon="nôtokêsiw" class="na" gcat="3sNA" sgloss="old_woman" stem="nôtokwêsiw" suffix="0">nôtokêsiw</w>
 ?</q>

--- a/source/SSSC/sssc22.xml
+++ b/source/SSSC/sssc22.xml
@@ -571,7 +571,7 @@
 <w canon="êtiskâyan" class="vai" gcat="2sAIcnj" prefix="IC" sgloss="step" stem="itiskê" suffix="-yan">êtiskâyan</w>
 ,
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
-<w canon="kâ-pê-itohtêyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj pê|thence" sgloss="go" stem="itohtê" suffix="-yan">kâ-pêh-itohtêyin</w>
+<w canon="kâ-pê-itohtêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj pê|thence" sgloss="go" stem="itohtê" suffix="-yan">kâ-pêh-itohtêyin</w>
 <w canon="ôta" class="ipc" gcat="IPC" sgloss="here" stem="ôta">ôtah</w>
 ?</q>
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">itwêw</w>
@@ -1865,7 +1865,7 @@
 <w canon="mîna" class="ipc" gcat="IPC" sgloss="also" stem="mîna">mîna</w>
 <w canon="kâ-ôh-awâsisîhkâsoyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence" sgloss="pretend_to_be_child" stem="awâsisîhkâso" suffix="-yan">k-ôh-awâsisîhkâsoyin</w>
 ,
-<w canon="kâ-pê-nayômikawiyin" class="vta" gcat="x2sTAcnj" preverbs="kâ|cnj pê|thence" sgloss="carry_on_back" stem="nayôm" suffix="-ikawiyan">kâ-pê-nayômikawiyin</w>
+<w canon="kâ-pê-nayômikawiyan" class="vta" gcat="x2sTAcnj" preverbs="kâ|cnj pê|thence" sgloss="carry_on_back" stem="nayôm" suffix="-ikawiyan">kâ-pê-nayômikawiyan</w>
 ?</q>
 <gloss>“Hey, why are you again acting like a child, being carried here on someone's back?”</gloss>
 </seg>
@@ -5776,7 +5776,7 @@
 <q>
 <w canon="awa" class="dem" gcat="3sDEM" sgloss="this" stem="awa">awa</w>
 <w canon="cî" class="ipc" gcat="IPC" sgloss="[?]" stem="cî">cî</w>
-<w canon="ê-mamisîyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="rely_on" stem="mamisî" suffix="-yan">ê-mamisiyin</w>
+<w canon="ê-mamisîyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="rely_on" stem="mamisî" suffix="-yan">ê-mamisiyan</w>
 ?</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 ,
@@ -5815,7 +5815,7 @@
 <q>
 <w canon="ôhi" class="dem" gcat="0pDEM" sgloss="this" stem="ôma" suffix="-0p">ôhi</w>
 <w canon="cî" class="ipc" gcat="IPC" sgloss="[?]" stem="cî">cî</w>
-<w canon="ê-mamisîyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="rely_on" stem="mamisî" suffix="-yan">ê-mamisiyin</w>
+<w canon="ê-mamisîyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="rely_on" stem="mamisî" suffix="-yan">ê-mamisiyan</w>
 ?</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 ,
@@ -6214,7 +6214,7 @@
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
 ,
 <w canon="êkosi" class="ipc" gcat="IPC" sgloss="thus" stem="êkosi">êkosi</w>
-<w canon="kê-paskiyawiyin" class="vta" gcat="2s1sTAcnj" preverbs="kê|IC+FUT" sgloss="beat_in_contest" stem="paskiyaw" suffix="-iyan">kê-paskiyawiyin</w>
+<w canon="kê-paskiyawiyan" class="vta" gcat="2s1sTAcnj" preverbs="kê|IC+FUT" sgloss="beat_in_contest" stem="paskiyaw" suffix="-iyan">kê-paskiyawiyan</w>
 !</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
 .
@@ -6348,7 +6348,7 @@
 <w canon="sâkohtâyani" class="vai" gcat="2sAIsubjunc" sgloss="overcome" stem="sâkôhtâ" suffix="-yani">sâkohtâyanih</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
 ,
-<w canon="kê-paskiyawiyin" class="vta" gcat="2s1sTAcnj" preverbs="kê|IC+FUT" sgloss="beat_in_contest" stem="paskiyaw" suffix="-iyan">kê-paskiyawiyin</w>
+<w canon="kê-paskiyawiyan" class="vta" gcat="2s1sTAcnj" preverbs="kê|IC+FUT" sgloss="beat_in_contest" stem="paskiyaw" suffix="-iyan">kê-paskiyawiyan</w>
 !</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
 .
@@ -7122,7 +7122,7 @@
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
 ?
 <w canon="tânitê" class="ipc" gcat="IPC" sgloss="where" stem="tânitê">tântê</w>
-<w canon="ê-ohtohtêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="come_from" stem="ohtohtê" suffix="-yan">êw-ohtohtêyin</w>
+<w canon="ê-ohtohtêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="come_from" stem="ohtohtê" suffix="-yan">êw-ohtohtêyin</w>
 !</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 <w canon="awa" class="dem" gcat="3sDEM" sgloss="this" stem="awa">aw</w>
@@ -7585,7 +7585,7 @@
 <q rend="PRE 1 POST0">
 <w canon="êkwa" class="ipc" gcat="IPC" sgloss="then" stem="êkwa">êkwah</w>
 <w canon="kiya" class="pr" gcat="2sPR" sgloss="you" stem="kiya">kiya</w>
-<w canon="kâ-pê-mêtawêyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj pê|thence" sgloss="play" stem="mêtawê" suffix="-yan">kâ-pê-mêtawiyin</w>
+<w canon="kâ-pê-mêtawêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj pê|thence" sgloss="play" stem="mêtawê" suffix="-yan">kâ-pê-mêtawiyan</w>
 ,
 <w canon="nâtakâm" class="ipc" gcat="IPC" sgloss="in_north" stem="nâtakâm">nâtakâm</w>
 <w canon="itohtê" class="vai" gcat="2sAIimp" sgloss="go" stem="itohtê" suffix="0">itohtêh</w>

--- a/source/SSSC/sssc22.xml
+++ b/source/SSSC/sssc22.xml
@@ -278,7 +278,7 @@
 <w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ê-papâ-nâtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj papâ|around" sgloss="fetch" stem="nât" suffix="-aman">êh-papâ-nâtaman</w>
 ,
-<w canon="kâ-papâmohtêyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="walk_about" stem="papâmohtê" suffix="-yan">kâ-papâmohtêyin</w>
+<w canon="kâ-papâmohtêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="walk_about" stem="papâmohtê" suffix="-yan">kâ-papâmohtêyan</w>
 ?</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
 .
@@ -571,7 +571,7 @@
 <w canon="êtiskâyan" class="vai" gcat="2sAIcnj" prefix="IC" sgloss="step" stem="itiskê" suffix="-yan">êtiskâyan</w>
 ,
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
-<w canon="kâ-pê-itohtêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj pê|thence" sgloss="go" stem="itohtê" suffix="-yan">kâ-pêh-itohtêyin</w>
+<w canon="kâ-pê-itohtêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj pê|thence" sgloss="go" stem="itohtê" suffix="-yan">kâ-pêh-itohtêyan</w>
 <w canon="ôta" class="ipc" gcat="IPC" sgloss="here" stem="ôta">ôtah</w>
 ?</q>
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">itwêw</w>
@@ -1708,7 +1708,7 @@
 <w canon="êyahâ" class="interj" gcat="INTERJ" sgloss="oho" stem="êyahâ">êyahâ</w>
 !
 <w canon="tânisi" class="ipc" gcat="IPC" sgloss="how" stem="tânisi">tânisih</w>
-<w canon="kâ-ôh-pêtôwatâmikawiyin" class="vta" gcat="x2sTAcnj" preverbs="kâ|cnj ôh|thence" sgloss="make_bring_a_load" stem="pêtôwatâm" suffix="-ikawiyan">k-ôh-pêtôwatâmikawiyin</w>
+<w canon="kâ-ôh-pêtôwatâmikawiyan" class="vta" gcat="x2sTAcnj" preverbs="kâ|cnj ôh|thence" sgloss="make_bring_a_load" stem="pêtôwatâm" suffix="-ikawiyan">k-ôh-pêtôwatâmikawiyin</w>
 ,
 <w canon="nôtokêsiw" class="na" gcat="3sNA" sgloss="old_woman" stem="nôtokwêsiw" suffix="0">nôtokêsiw</w>
 ?</q>
@@ -1863,7 +1863,7 @@
 <w canon="tânisi" class="ipc" gcat="IPC" sgloss="how" stem="tânisi">tânisih</w>
 <w canon="mâka" class="ipc" gcat="IPC" sgloss="but" stem="mâka">mâka</w>
 <w canon="mîna" class="ipc" gcat="IPC" sgloss="also" stem="mîna">mîna</w>
-<w canon="kâ-ôh-awâsisîhkâsoyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence" sgloss="pretend_to_be_child" stem="awâsisîhkâso" suffix="-yan">k-ôh-awâsisîhkâsoyin</w>
+<w canon="kâ-ôh-awâsisîhkâsoyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence" sgloss="pretend_to_be_child" stem="awâsisîhkâso" suffix="-yan">k-ôh-awâsisîhkâsoyin</w>
 ,
 <w canon="kâ-pê-nayômikawiyan" class="vta" gcat="x2sTAcnj" preverbs="kâ|cnj pê|thence" sgloss="carry_on_back" stem="nayôm" suffix="-ikawiyan">kâ-pê-nayômikawiyan</w>
 ?</q>
@@ -6073,7 +6073,7 @@
 <w canon="sâkohikawiyahko" class="vta" gcat="x1iTAsubjunc" sgloss="overcome" stem="sâkoh" suffix="-ikawiyahko">sâkohikawiyahkoh</w>
 ,
 <w canon="êyakonik" class="pr" gcat="3pPR" sgloss="that_one" stem="êwako" suffix="-3p">êyakonik</w>
-<w canon="ta-mêkinawêyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="give_up" stem="mêkinawê" suffix="-yan">ta-mêkinawiyin</w>
+<w canon="ta-mêkinawêyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="give_up" stem="mêkinawê" suffix="-yan">ta-mêkinawiyan</w>
 .</q>
 <gloss>It happens that even if we are not defeated, you are to give them up.</gloss>
 </seg>
@@ -6469,7 +6469,7 @@
 <w canon="opahcâwiyak" class="na" gcat="3pNA" sgloss="levitators" stem="opahcâwiy" suffix="-ak">opahcâwiyak</w>
 ,
 <w canon="ita" class="ipc" gcat="IPC" sgloss="there" stem="ita">itah</w>
-<w canon="kita-nîpawiyin" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="stand" stem="nîpawi" suffix="-yan">kita-nîpawiyin</w>
+<w canon="kita-nîpawiyan" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="stand" stem="nîpawi" suffix="-yan">kita-nîpawiyan</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 <w canon="okosisa" class="nda" gcat="3oNDAof3s" prefix="3" sgloss="son" stem="kosis" suffix="-a">okosisah</w>
@@ -7008,7 +7008,7 @@
 <w canon="nîpihki" class="vii" gcat="0sIIsubjunc" sgloss="be_summer" stem="nîpin" suffix="-ki">nîpihki</w>
 ,
 <w canon="êkota" class="ipc" gcat="IPC" sgloss="there" stem="êkota">êkotah</w>
-<w canon="kâ-wî-mêtawêyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj wî|will" sgloss="play" stem="mêtawê" suffix="-yan">kâ-wîh-mêtawêyin</w>
+<w canon="kâ-wî-mêtawêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj wî|will" sgloss="play" stem="mêtawê" suffix="-yan">kâ-wîh-mêtawêyan</w>
 .</q>
 <gloss>As the warm weather comes on, well on into summer, that is when you will be contending.”</gloss>
 </seg>

--- a/source/SSSC/sssc24.xml
+++ b/source/SSSC/sssc24.xml
@@ -1326,7 +1326,7 @@
 <w canon="yâhki" class="ipc" gcat="IPC" sgloss="pretend" stem="yâhki">yâhkih</w>
 <w canon="kikaskêyihtên" class="vti" gcat="2sTI" prefix="2" sgloss="be_sad_over" stem="kaskêyiht" suffix="-ên">kikaskêyihtên</w>
 ,
-<w canon="ê-wî-wâpamiyin" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj wî|will" sgloss="see" stem="wâpam" suffix="-iyan">ê-wîh-wâpamiyin</w>
+<w canon="ê-wî-wâpamiyan" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj wî|will" sgloss="see" stem="wâpam" suffix="-iyan">ê-wîh-wâpamiyan</w>
 ,
 <w canon="ê-kiskêyihtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj" sgloss="know" stem="kiskêyiht" suffix="-aman">ê-kiskêyihtaman</w>
 <w canon="ôta" class="ipc" gcat="IPC" sgloss="here" stem="ôta">ôtah</w>
@@ -1363,7 +1363,7 @@
 <w canon="kitakohtân" class="vta" gcat="2s3sTAimp" preverbs="kita|to" sgloss="immerse" stem="kohtân" suffix="0">kitakohtân</w>
 ,
 <w canon="kayâs" class="ipc" gcat="IPC" sgloss="long_ago" stem="kayâs">kayâs</w>
-<w canon="ê-takohtêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="arrive" stem="takohtê" suffix="-yan">êh-takohtêyin</w>
+<w canon="ê-takohtêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="arrive" stem="takohtê" suffix="-yan">êh-takohtêyin</w>
 <w canon="ta-kî-kisâtaman" class="vti" gcat="2sTIcnj" preverbs="ta|FUT kî|can" sgloss="stay_with" stem="kisât" suffix="-aman">ta-kî-kisâtaman</w>
 <w canon="sêmâk" class="ipc" gcat="IPC" sgloss="right_away" stem="sêmâk">sêmâk</w>
 ,</q>
@@ -2688,7 +2688,7 @@
 <q>
 <w canon="tâpwê" class="ipc" gcat="IPC" sgloss="truly" stem="tâpwê">tâpwê</w>
 <w canon="nimiywêyihtên" class="vti" gcat="1sTI" prefix="1" sgloss="consider_good" stem="miywêyiht" suffix="-ên">nimiywêyihtên</w>
-<w canon="ê-takohtêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="arrive" stem="takohtê" suffix="-yan">êh-takohtêyin</w>
+<w canon="ê-takohtêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="arrive" stem="takohtê" suffix="-yan">êh-takohtêyin</w>
 ,</q>
 <w canon="ê-itikot" class="vta" gcat="3o3sTAcnj" preverbs="ê|cnj" sgloss="say_to" stem="it" suffix="-ikot">êh-itikot</w>
 ;
@@ -2993,9 +2993,9 @@
 <w canon="kâ-tôtawât" class="vta" gcat="3s3oTAcnj" preverbs="kâ|cnj" sgloss="do_thus_to" stem="tôtaw" suffix="-ât">kâ-tôtawât</w>
 <w canon="wîtimwa" class="nda" gcat="3oNDAof3s" prefix="3" sgloss="cousin" stem="îtim" suffix="-a">wîtimwa</w>
 ,
-<w canon="ôh-pê-kakwâtakihtâyin" class="vai" gcat="2sAIcnj" preverbs="ôh|thence pê|thence" sgloss="suffer" stem="kakwâtakihtâ" suffix="-yan">ôh-pêh-kakwâtakihtayin</w>
+<w canon="ôh-pê-kakwâtakihtâyan" class="vai" gcat="2sAIcnj" preverbs="ôh|thence pê|thence" sgloss="suffer" stem="kakwâtakihtâ" suffix="-yan">ôh-pêh-kakwâtakihtayin</w>
 ,
-<w canon="ê-pê-itohtêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj pê|thence" sgloss="go" stem="itohtê" suffix="-yan">êh-pêy-itohtêyin</w>
+<w canon="ê-pê-itohtêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj pê|thence" sgloss="go" stem="itohtê" suffix="-yan">êh-pêy-itohtêyin</w>
 ,</q>
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">itwêw</w>
 ;
@@ -4842,7 +4842,7 @@
 ,
 <w canon="ê-itêyihtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj" sgloss="think_of" stem="itêyiht" suffix="-aman">êh-têyihtaman</w>
 ,
-<w canon="kâ-ôh-pê-wîkimiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj ôh|thence pê|thence" sgloss="live_with" stem="wîkim" suffix="-iyan">k-ôh-pê-wîkimiyin</w>
+<w canon="kâ-ôh-pê-wîkimiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj ôh|thence pê|thence" sgloss="live_with" stem="wîkim" suffix="-iyan">k-ôh-pê-wîkimiyan</w>
 ,</q>
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">itwêw</w>
 <w canon="macihkiwis" class="na" gcat="3sNA" sgloss="bad_fellow" stem="macihkiwis" suffix="0">macihkiwis</w>

--- a/source/SSSC/sssc24.xml
+++ b/source/SSSC/sssc24.xml
@@ -4842,7 +4842,7 @@
 ,
 <w canon="ê-itêyihtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj" sgloss="think_of" stem="itêyiht" suffix="-aman">êh-têyihtaman</w>
 ,
-<w canon="kâ-ôh-pê-wîkimiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj ôh|thence pê|thence" sgloss="live_with" stem="wîkim" suffix="-iyan">k-ôh-pê-wîkimiyan</w>
+<w canon="kâ-oh-pê-wîkimiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj ôh|thence pê|thence" sgloss="live_with" stem="wîkim" suffix="-iyan">k-ôh-pê-wîkimiyan</w>
 ,</q>
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">itwêw</w>
 <w canon="macihkiwis" class="na" gcat="3sNA" sgloss="bad_fellow" stem="macihkiwis" suffix="0">macihkiwis</w>

--- a/source/SSSC/sssc26.xml
+++ b/source/SSSC/sssc26.xml
@@ -2213,7 +2213,7 @@
 ,
 <q>
 <w canon="tânêhki" class="ipc" gcat="IPC" sgloss="why" stem="tânêhki">tânêhki</w>
-<w canon="kâ-ôh-itwêyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence" sgloss="say" stem="itwê" suffix="-yan">k-ôh-itwêyin</w>
+<w canon="kâ-ôh-itwêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence" sgloss="say" stem="itwê" suffix="-yan">k-ôh-itwêyin</w>
 ?</q>
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">itwêw</w>
 <w canon="awa" class="dem" gcat="3sDEM" sgloss="this" stem="awa">awa</w>
@@ -2230,7 +2230,7 @@
 ,
 <w canon="mistahi" class="ipc" gcat="IPC" sgloss="greatly" stem="mistahi">mistahi</w>
 <w canon="kâ-nitawêyihtaman" class="vti" gcat="2sTIcnj" preverbs="kâ|cnj" sgloss="want" stem="nitawêyiht" suffix="-aman">kâ-ntawêyihtaman</w>
-<w canon="kita-mîciyin" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="eat" stem="mîci" suffix="-yan">kita-mîciyin</w>
+<w canon="kita-mîciyan" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="eat" stem="mîci" suffix="-yan">kita-mîciyan</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 <w canon="êsa" class="ipc" gcat="IPC" sgloss="reportedly" stem="êsa">êsa</w>

--- a/source/SSSC/sssc26.xml
+++ b/source/SSSC/sssc26.xml
@@ -2411,7 +2411,7 @@
 <w canon="mâ" class="interj" gcat="INTERJ" sgloss="yes" stem="mâ">m</w>
 <w canon="ani" class="ipc" gcat="IPC" sgloss="then" stem="ani">âni</w>
 <w canon="âta" class="ipc" gcat="IPC" sgloss="although" stem="âta">âtah</w>
-<w canon="ê-manitôwakêyimoyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="think_self_powered" stem="manitôwakêyimo" suffix="-yan">êh-manitôwakêyimoyin</w>
+<w canon="ê-manitowakêyimoyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="think_self_powered" stem="manitôwakêyimo" suffix="-yan">êh-manitôwakêyimoyin</w>
 ,
 <w canon="ita" class="ipc" gcat="IPC" sgloss="there" stem="ita">itah</w>
 <w canon="wiya" class="ipc" gcat="IPC" sgloss="WIYA" stem="wiya">wiya</w>

--- a/source/SSSC/sssc26.xml
+++ b/source/SSSC/sssc26.xml
@@ -2325,7 +2325,7 @@
 ,
 <w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ita" class="ipc" gcat="IPC" sgloss="there" stem="ita">itah</w>
-<w canon="kê-kitimâkêyimikoyin" class="vta" gcat="0x2sTAcnji" preverbs="kê|IC+FUT" sgloss="pity" stem="kitimâkêyim" suffix="-ikoyan">kê-kitimâkêyimikoyin</w>
+<w canon="kê-kitimâkêyimikoyan" class="vta" gcat="0x2sTAcnji" preverbs="kê|IC+FUT" sgloss="pity" stem="kitimâkêyim" suffix="-ikoyan">kê-kitimâkêyimikoyan</w>
 ?</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
 <w canon="êsa" class="ipc" gcat="IPC" sgloss="reportedly" stem="êsa">êsah</w>
@@ -2411,7 +2411,7 @@
 <w canon="mâ" class="interj" gcat="INTERJ" sgloss="yes" stem="mâ">m</w>
 <w canon="ani" class="ipc" gcat="IPC" sgloss="then" stem="ani">âni</w>
 <w canon="âta" class="ipc" gcat="IPC" sgloss="although" stem="âta">âtah</w>
-<w canon="ê-manitôwakêyimoyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="think_self_powered" stem="manitôwakêyimo" suffix="-yan">êh-manitôwakêyimoyin</w>
+<w canon="ê-manitôwakêyimoyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="think_self_powered" stem="manitôwakêyimo" suffix="-yan">êh-manitôwakêyimoyin</w>
 ,
 <w canon="ita" class="ipc" gcat="IPC" sgloss="there" stem="ita">itah</w>
 <w canon="wiya" class="ipc" gcat="IPC" sgloss="WIYA" stem="wiya">wiya</w>

--- a/source/SSSC/sssc27.xml
+++ b/source/SSSC/sssc27.xml
@@ -684,7 +684,7 @@
 ,
 <w canon="oskinîkiw" class="na" gcat="3sNA" sgloss="young_man" stem="oskinîkiw" suffix="0">oskinîkiw</w>
 ,
-<w canon="kâ-ôh-isiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj ôh|thence" sgloss="say_to" stem="it" suffix="-iyan">k-ôh-isiyin</w>
+<w canon="kâ-ôh-isiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj ôh|thence" sgloss="say_to" stem="it" suffix="-iyan">k-ôh-isiyin</w>
 ?</q>
 <gloss>Then, “What do you mean, youth?”</gloss>
 </seg>
@@ -710,7 +710,7 @@
 <w canon="wâkayôs" class="na" gcat="3sNA" sgloss="bear" stem="wâkayôs" suffix="0">wâkayôs</w>
 <w canon="ê-kî-kimotamâsk" class="vta" gcat="3s2sTAcnj" preverbs="ê|cnj kî|PAST" sgloss="steal_from" stem="kimotamaw" suffix="-isk">ê-kîh-kimotamâsk</w>
 ,
-<w canon="kâ-ôh-kî-wanihiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj ôh|thence kî|PAST" sgloss="lose" stem="wanih" suffix="-iyan">k-ô-kih-wanihiyin</w>
+<w canon="kâ-ôh-kî-wanihiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj ôh|thence kî|PAST" sgloss="lose" stem="wanih" suffix="-iyan">k-ô-kih-wanihiyin</w>
 ,</q>
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">itwêw</w>
 <w canon="êsa" class="ipc" gcat="IPC" sgloss="reportedly" stem="êsa">êsah</w>

--- a/source/SSSC/sssc27.xml
+++ b/source/SSSC/sssc27.xml
@@ -936,7 +936,7 @@
 <w canon="ana" class="dem" gcat="3sDEM" sgloss="that" stem="ana">âna</w>
 <w canon="êkâ" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâ">êkâ</w>
 <w canon="wîhkâc" class="ipc" gcat="IPC" sgloss="ever" stem="wîhkâc">wîhkâc</w>
-<w canon="kê-wâpamiyin" class="vta" gcat="2s1sTAcnj" preverbs="kê|IC+FUT" sgloss="see" stem="wâpam" suffix="-iyan">kê-wâpamiyin</w>
+<w canon="kê-wâpamiyan" class="vta" gcat="2s1sTAcnj" preverbs="kê|IC+FUT" sgloss="see" stem="wâpam" suffix="-iyan">kê-wâpamiyan</w>
 !</q>
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">itwêw</w>
 <w canon="awa" class="dem" gcat="3sDEM" sgloss="this" stem="awa">awa</w>

--- a/source/SSSC/sssc27.xml
+++ b/source/SSSC/sssc27.xml
@@ -710,7 +710,7 @@
 <w canon="wâkayôs" class="na" gcat="3sNA" sgloss="bear" stem="wâkayôs" suffix="0">wâkayôs</w>
 <w canon="ê-kî-kimotamâsk" class="vta" gcat="3s2sTAcnj" preverbs="ê|cnj kî|PAST" sgloss="steal_from" stem="kimotamaw" suffix="-isk">ê-kîh-kimotamâsk</w>
 ,
-<w canon="kâ-ôh-kî-wanihiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj ôh|thence kî|PAST" sgloss="lose" stem="wanih" suffix="-iyan">k-ô-kih-wanihiyin</w>
+<w canon="kâ-oh-kî-wanihiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj ôh|thence kî|PAST" sgloss="lose" stem="wanih" suffix="-iyan">k-ô-kih-wanihiyin</w>
 ,</q>
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">itwêw</w>
 <w canon="êsa" class="ipc" gcat="IPC" sgloss="reportedly" stem="êsa">êsah</w>

--- a/source/SSSC/sssc28.xml
+++ b/source/SSSC/sssc28.xml
@@ -1055,7 +1055,7 @@
 <w canon="kika-kaskikwâtison" class="vai" gcat="2sAI" prefix="2" preverbs="ka|will" sgloss="sew_for_self" stem="kaskikwâtiso" suffix="-n">kika-kaskikwâtison</w>
 ,
 <w canon="ahpô" class="ipc" gcat="IPC" sgloss="even" stem="ahpô">ahpoh</w>
-<w canon="ê-miyomahcihoyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="fare_well" stem="miyomahciho" suffix="-yan">êh-miyômahcihoyin</w>
+<w canon="ê-miyomahcihoyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="fare_well" stem="miyomahciho" suffix="-yan">êh-miyômahcihoyin</w>
 ;</q>
 <gloss>You are never to do your own sewing, even when you are well;</gloss>
 </seg>
@@ -2958,7 +2958,7 @@
 <w canon="aspapiwin" class="ni" gcat="0sNI" sgloss="saddle" stem="aspapiwin" suffix="0">aspapiwin</w>
 ,
 <w canon="ohcitaw" class="ipc" gcat="IPC" sgloss="expressly" stem="ohcitaw">ohcitaw</w>
-<w canon="ta-kîwê-têhtapiyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT kîwê|back" sgloss="be_mounted" stem="têhtapi" suffix="-yan">ta-kîwê-têhtapiyin</w>
+<w canon="ta-kîwê-têhtapiyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT kîwê|back" sgloss="be_mounted" stem="têhtapi" suffix="-yan">ta-kîwê-têhtapiyan</w>
 ,</q>
 <w canon="kika-itik" class="vta" gcat="3s2sTA" prefix="2" preverbs="ka|will" sgloss="say_to" stem="it" suffix="-ik">kik-êtik</w>
 ,
@@ -3701,7 +3701,7 @@
 ,
 <w canon="êkosi" class="ipc" gcat="IPC" sgloss="thus" stem="êkosi">êkos</w>
 <w canon="ani" class="ipc" gcat="IPC" sgloss="then" stem="ani">âni</w>
-<w canon="ta-pê-kîwêyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT pê|thence" sgloss="go_home" stem="kîwê" suffix="-yan">ta-pê-kîwêyin</w>
+<w canon="ta-pê-kîwêyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT pê|thence" sgloss="go_home" stem="kîwê" suffix="-yan">ta-pê-kîwêyan</w>
 .</q>
 <gloss>“But if he puts you on its back, then indeed you will come home.</gloss>
 </seg>
@@ -7516,7 +7516,7 @@
 <w canon="mistahi" class="ipc" gcat="IPC" sgloss="greatly" stem="mistahi">mistah</w>
 <w canon="êcika" class="ipc" gcat="IPC" sgloss="what_is_this" stem="êcika">êcik</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
-<w canon="ê-kakêpâtisiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_foolish" stem="kakêpâtisi" suffix="-yan">êh-kakêpâtisiyin</w>
+<w canon="ê-kakêpâtisiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_foolish" stem="kakêpâtisi" suffix="-yan">êh-kakêpâtisiyin</w>
 !</q>
 <gloss>When they had sat down there, “And so it appears that you are of a most evil nature!</gloss>
 </seg>

--- a/source/SSSC/sssc28.xml
+++ b/source/SSSC/sssc28.xml
@@ -270,7 +270,7 @@
 ,
 <w canon="ê-wî-wîhtamâtân" class="vta" gcat="1s2sTAcnj" preverbs="ê|cnj wî|will" sgloss="tell_about" stem="wîhtamaw" suffix="-itân">ê-wîh-wîhtamâtân</w>
 ,
-<w canon="kita-ôh-owîcimosiyin" class="vai" gcat="2sAIcnj" preverbs="kita|to ôh|thence" sgloss="have_sweetheart" stem="owîcimosi" suffix="-yan">kit-ôh-owîcimosimiyin</w>
+<w canon="kita-ôh-owîcimosiyan" class="vai" gcat="2sAIcnj" preverbs="kita|to ôh|thence" sgloss="have_sweetheart" stem="owîcimosi" suffix="-yan">kit-ôh-owîcimosimiyin</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 ,
@@ -2187,7 +2187,7 @@
 <w canon="nôsisê" class="nda" extra="voc" gcat="3sNDAof1svoc" prefix="1" sgloss="grandchild" stem="ôsisim">nôsisê</w>
 ,
 <w canon="nawac" class="ipc" gcat="IPC" sgloss="more" stem="nawac">nawac</w>
-<w canon="ta-kîwêyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="go_home" stem="kîwê" suffix="-yan">ta-kîwêyin</w>
+<w canon="ta-kîwêyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="go_home" stem="kîwê" suffix="-yan">ta-kîwêyan</w>
 ,
 <w canon="wâpahki" class="ipc" gcat="IPC" sgloss="tomorrow" stem="wâpahki">wâpahkih</w>
 .</q>
@@ -4122,12 +4122,12 @@
 ,
 <w canon="tita-otinaman" class="vti" gcat="2sTIcnj" preverbs="kita|to" sgloss="take" stem="otin" suffix="-aman">tit-ôtinaman</w>
 ,
-<w canon="ci-ta-âpacihtâyin" class="vai" gcat="2sAIcnj" preverbs="ci|so_that ta|FUT" sgloss="use" stem="âpacihtâ" suffix="-yan">ci-t-âpacihtâyin</w>
+<w canon="ci-ta-âpacihtâyan" class="vai" gcat="2sAIcnj" preverbs="ci|so_that ta|FUT" sgloss="use" stem="âpacihtâ" suffix="-yan">ci-t-âpacihtâyin</w>
 <w canon="awa" class="dem" gcat="3sDEM" sgloss="this" stem="awa">ô</w>
 <w canon="ka-miyitân" class="vta" gcat="1s2sTAcnj" preverbs="ka|will" sgloss="give_to" stem="miy" suffix="-itân">ka-miyitân</w>
 <w canon="nitêm" class="nda" gcat="3sNDAof1s" prefix="1" sgloss="dog" stem="têm" suffix="0">ntêm</w>
 ,
-<w canon="ta-kîwêyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="go_home" stem="kîwê" suffix="-yan">ta-kîwêyin</w>
+<w canon="ta-kîwêyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="go_home" stem="kîwê" suffix="-yan">ta-kîwêyan</w>
 .</q>
 <gloss>Over on this side you will see a beaded saddle, and an excellent rawhide thong bridle, that you may take to use on this my horse which I shall give you, when you go home.”</gloss>
 </seg>
@@ -5046,7 +5046,7 @@
 <q rend="PRE 0 POST1">
 <w canon="iyikohk" class="ipc" gcat="IPC" sgloss="so_much" stem="iyikohk">iyikoh</w>
 <w canon="mâna" class="ipc" gcat="IPC" sgloss="usually" stem="mâna">mâna</w>
-<w canon="kâ-koskoniyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="awaken_by_hand" stem="koskon" suffix="-iyan">kâ-koskoniyin</w>
+<w canon="kâ-koskoniyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="awaken_by_hand" stem="koskon" suffix="-iyan">kâ-koskoniyan</w>
 ,
 <w canon="êkoyikohk" class="ipc" gcat="IPC" sgloss="that_much" stem="êkoyikohk">êkoyikohk</w>
 <w canon="ka-koskonin" class="vta" gcat="2s1sTA" preverbs="ka|will" sgloss="awaken_by_hand" stem="koskon" suffix="-in">ka-koskonin</w>
@@ -5327,7 +5327,7 @@
 <q rend="PRE 0 POST1">
 <w canon="iyikohk" class="ipc" gcat="IPC" sgloss="so_much" stem="iyikohk">iyikoh</w>
 <w canon="mâna" class="ipc" gcat="IPC" sgloss="usually" stem="mâna">mâna</w>
-<w canon="kâ-koskoniyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="awaken_by_hand" stem="koskon" suffix="-iyan">kâ-koskoniyin</w>
+<w canon="kâ-koskoniyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="awaken_by_hand" stem="koskon" suffix="-iyan">kâ-koskoniyan</w>
 ,
 <w canon="êkoyikohk" class="ipc" gcat="IPC" sgloss="that_much" stem="êkoyikohk">êkoyikoh</w>
 <w canon="koskonîhkan" class="vta" gcat="2s1sTAdelimp" sgloss="awaken_by_hand" stem="koskon" suffix="-îhkan">koskonihkân</w>
@@ -5700,7 +5700,7 @@
 <w canon="nôsisê" class="nda" extra="voc" gcat="3sNDAof1svoc" prefix="1" sgloss="grandchild" stem="ôsisim">nôsisê</w>
 ,
 <w canon="wâhyaw" class="ipc" gcat="IPC" sgloss="far_away" stem="wâhyaw">wâhyaw</w>
-<w canon="kâ-ohtohtêyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="come_from" stem="ohtohtê" suffix="-yan">k-ôhtohtêyin</w>
+<w canon="kâ-ohtohtêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="come_from" stem="ohtohtê" suffix="-yan">k-ôhtohtêyin</w>
 .</q>
 <gloss>“Now then, my grandson, you have come from afar.</gloss>
 </seg>
@@ -7035,10 +7035,10 @@
 <w canon="ê-kî-itêyimitân" class="vta" gcat="1s2sTAcnj" preverbs="ê|cnj kî|PAST" sgloss="think_thus_of" stem="itêyim" suffix="-itân">ê-kîh-itêyimitân</w>
 ,
 <w canon="anima" class="dem" gcat="0sDEM" sgloss="that" stem="anima">anima</w>
-<w canon="kâ-kî-tôtawiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj kî|PAST" sgloss="do_thus_to" stem="tôtaw" suffix="-iyan">ka-kîh-tôtawiyin</w>
+<w canon="kâ-kî-tôtawiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj kî|PAST" sgloss="do_thus_to" stem="tôtaw" suffix="-iyan">ka-kîh-tôtawiyin</w>
 ,
 <w canon="kêkâc" class="ipc" gcat="IPC" sgloss="almost" stem="kêkâc">kêkâc</w>
-<w canon="kâ-nipahiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="kill" stem="nipah" suffix="-iyan">kâ-nipahiyin</w>
+<w canon="kâ-nipahiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="kill" stem="nipah" suffix="-iyan">kâ-nipahiyan</w>
 ?</q>
 <gloss>“Why, when I thought of you, ‘He loves me,’ did you do that to me, when you nearly killed me?</gloss>
 </seg>

--- a/source/SSSC/sssc30.xml
+++ b/source/SSSC/sssc30.xml
@@ -2696,7 +2696,7 @@
 <w canon="nôhkô" class="nda" extra="voc" gcat="3sNDAof1svoc" prefix="1" sgloss="grandmother" stem="ôhkom">nôhko</w>
 ,
 <w canon="êkâ" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâ">êkâ</w>
-<w canon="kâ-ôh-mîcisoyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence" sgloss="eat" stem="mîciso" suffix="-yan">k-oh-mîcisoyin</w>
+<w canon="kâ-ôh-mîcisoyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ôh|thence" sgloss="eat" stem="mîciso" suffix="-yan">k-oh-mîcisoyin</w>
 ?</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 <w canon="ôhkoma" class="nda" gcat="3oNDA" sgloss="grandmother" stem="ôhkom" suffix="-a">ôhkoma</w>
@@ -3552,7 +3552,7 @@
 <q>
 <w canon="kiya" class="pr" gcat="2sPR" sgloss="you" stem="kiya">kiy</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
-<w canon="kâ-misi-wanâtahkamikisiyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="make_mess_of_things" stem="misiwanâtahkamikisi" suffix="-yan">kâ-misi-wanâtahkamikisiyin</w>
+<w canon="kâ-misi-wanâtahkamikisiyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="make_mess_of_things" stem="misiwanâtahkamikisi" suffix="-yan">kâ-misi-wanâtahkamikisiyan</w>
 !</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .
@@ -4023,7 +4023,7 @@
 ,
 <w canon="kiya" class="pr" gcat="2sPR" sgloss="you" stem="kiya">kiy</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
-<w canon="kâ-wîwiyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="have_wife" stem="wîwi" suffix="-yan">kâ-wîwiyin</w>
+<w canon="kâ-wîwiyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="have_wife" stem="wîwi" suffix="-yan">kâ-wîwiyan</w>
 .</q>
 <gloss>“Nonsense, brother-in-law, it is you, rather, who have taken her to wife.</gloss>
 </seg>
@@ -4404,7 +4404,7 @@
 !
 <w canon="pêyakwan" class="ipc" gcat="IPC" sgloss="the_same" stem="pêyakwan">pêyakwan</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
-<w canon="kâ-isinâkosiyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="look_thus" stem="isinâkosi" suffix="-yan">kây-isinâkosiyin</w>
+<w canon="kâ-isinâkosiyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="look_thus" stem="isinâkosi" suffix="-yan">kây-isinâkosiyin</w>
 ,
 <w canon="êkosi" class="ipc" gcat="IPC" sgloss="thus" stem="êkosi">êkosi</w>
 <w canon="kika-isinâkosin" class="vai" gcat="2sAI" prefix="2" preverbs="ka|will" sgloss="look_thus" stem="isinâkosi" suffix="-n">kik-êsinâkosin</w>

--- a/source/SSSC/sssc30.xml
+++ b/source/SSSC/sssc30.xml
@@ -2952,7 +2952,7 @@
 <w canon="hâ" class="ipc" gcat="IPC" sgloss="oh" stem="hâ">hâ</w>
 ,
 <w canon="wiya" class="ipc" gcat="IPC" sgloss="WIYA" stem="wiya">wiy</w>
-<w canon="ê-sâkwêyimoyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_unwilling" stem="sâkwêyimo" suffix="-yan">ê-sâkwêyimoyin</w>
+<w canon="ê-sâkwêyimoyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_unwilling" stem="sâkwêyimo" suffix="-yan">ê-sâkwêyimoyan</w>
 ,
 <w canon="kiyâm" class="ipc" gcat="IPC" sgloss="oh_well" stem="kiyâm">kiyâm</w>
 <w canon="ici" class="ipc" gcat="IPC" sgloss="later" stem="ici">ici</w>
@@ -3875,7 +3875,7 @@
 <q>
 <w canon="nâpêw" class="na" gcat="3sNA" sgloss="man" stem="nâpêw" suffix="0">nâpêw</w>
 </q>
-<w canon="ê-pakosihtâyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="beg_for" stem="pakosihtâ" suffix="-yan">ê-pakosîhtâyin</w>
+<w canon="ê-pakosihtâyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="beg_for" stem="pakosihtâ" suffix="-yan">ê-pakosîhtâyan</w>
 .</q>
 <gloss>And so at last you have that which you begged for, saying, ‘a man.’</gloss>
 </seg>

--- a/source/SSSC/sssc30.xml
+++ b/source/SSSC/sssc30.xml
@@ -3875,7 +3875,7 @@
 <q>
 <w canon="nâpêw" class="na" gcat="3sNA" sgloss="man" stem="nâpêw" suffix="0">nâpêw</w>
 </q>
-<w canon="ê-pakosihtâyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="beg_for" stem="pakosihtâ" suffix="-yan">ê-pakosîhtâyan</w>
+<w canon="ê-pakosîhtâyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="beg_for" stem="pakosihtâ" suffix="-yan">ê-pakosîhtâyan</w>
 .</q>
 <gloss>And so at last you have that which you begged for, saying, ‘a man.’</gloss>
 </seg>

--- a/source/SSSC/sssc32.xml
+++ b/source/SSSC/sssc32.xml
@@ -1786,7 +1786,7 @@
 ,
 <w canon="êkâ" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâ">êkâ</w>
 <w canon="mayaw" class="ipc" gcat="IPC" sgloss="as_soon_as" stem="mayaw">mayaw</w>
-<w canon="ê-takosiniyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="arrive" stem="takosin" suffix="-yan">êh-takosiniyin</w>
+<w canon="ê-takosiniyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="arrive" stem="takosin" suffix="-yan">êh-takosiniyin</w>
 .</q>
 <gloss>“You deprived yourself of much pleasure, coming late.</gloss>
 </seg>

--- a/source/SSSC/sssc33.xml
+++ b/source/SSSC/sssc33.xml
@@ -525,7 +525,7 @@
 <w canon="tânitê" class="ipc" gcat="IPC" sgloss="where" stem="tânitê">tântê</w>
 <w canon="ê-kî-itâmoyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj kî|can" sgloss="flee" stem="itâmo" suffix="-yan">êh-kiy-itâmoyan</w>
 ,
-<w canon="kâ-kîsinâcihiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="make_grieve" stem="kîsinâcih" suffix="-iyan">kâ-kîsinacihiyin</w>
+<w canon="kâ-kîsinâcihiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="make_grieve" stem="kîsinâcih" suffix="-iyan">kâ-kîsinacihiyan</w>
 ,
 <w canon="nôhkom" class="nda" gcat="3sNDAof1s" prefix="1" sgloss="grandmother" stem="ôhkom" suffix="0">nôhkom</w>
 <w canon="ê-nipahat" class="vta" gcat="2s3sTAcnj" preverbs="ê|cnj" sgloss="kill" stem="nipah" suffix="-at">êh-nipahat</w>

--- a/source/SSSC/sssc34.xml
+++ b/source/SSSC/sssc34.xml
@@ -869,7 +869,7 @@
 <w canon="ayisk" class="ipc" gcat="IPC" sgloss="for" stem="ayis">ayisk</w>
 <w canon="kikakêpâtisin" class="vai" gcat="2sAI" prefix="2" sgloss="be_foolish" stem="kakêpâtisi" suffix="-n">kikâkêpâtisin</w>
 ,
-<w canon="ê-kî-nôhtê-onâpêmiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj kî|PAST nôhtê|want_to" sgloss="have_husband" stem="onâpêmi" suffix="-yan">êh-kîh-nôhtêh-onâpêmiyin</w>
+<w canon="ê-kî-nôhtê-onâpêmiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj kî|PAST nôhtê|want_to" sgloss="have_husband" stem="onâpêmi" suffix="-yan">êh-kîh-nôhtêh-onâpêmiyin</w>
 <w canon="acâhkos" class="na" gcat="3sNA" sgloss="star" stem="acâhkos" suffix="0">acâhkos</w>
 ,</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
@@ -1699,13 +1699,13 @@
 ,
 <w canon="ê-mâyâtisiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="be_ugly" stem="mâyâtisi" suffix="-yan">êh-mâyâtisiyan</w>
 ,
-<w canon="ê-pitikohkwêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="have_round_face" stem="pitikohkwê" suffix="-yan">êh-pitikohkwêyin</w>
+<w canon="ê-pitikohkwêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="have_round_face" stem="pitikohkwê" suffix="-yan">êh-pitikohkwêyin</w>
 ,
 <w canon="êkwa" class="ipc" gcat="IPC" sgloss="then" stem="êkwa">êkwah</w>
-<w canon="ê-mamâhkisitêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="have_big_feet" stem="mamâhkisitê" suffix="-yan">êh-mâmâhkisitêyin</w>
+<w canon="ê-mamâhkisitêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="have_big_feet" stem="mamâhkisitê" suffix="-yan">êh-mâmâhkisitêyin</w>
 ,
 <w canon="êkwa" class="ipc" gcat="IPC" sgloss="then" stem="êkwa">êkw</w>
-<w canon="ê-nâ-napakâskitoyêyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj dupH|H.REDUP" sgloss="have_flat_buttocks" stem="napakâskitoyê" suffix="-yan">ê-nâ-napakâskitoyêyin</w>
+<w canon="ê-nâ-napakâskitoyêyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj dupH|H.REDUP" sgloss="have_flat_buttocks" stem="napakâskitoyê" suffix="-yan">ê-nâ-napakâskitoyêyan</w>
 ?</q>
 <gloss>“Ho ho, do you suppose we would marry you in any case, you ugly fellow, with your crumpled-up snout and your big feet and your flat rump?”</gloss>
 </seg>
@@ -3691,7 +3691,7 @@
 
 <seg n="133.2">
 <q rend="PRE 0 POST0">
-<w canon="ê-kâtawiyin" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj" sgloss="hide_it_from" stem="kâtaw" suffix="-iyan">êh-kâtwawiyin</w>
+<w canon="ê-kâtawiyan" class="vta" gcat="2s1sTAcnj" preverbs="ê|cnj" sgloss="hide_it_from" stem="kâtaw" suffix="-iyan">êh-kâtwawiyin</w>
 ,
 <w canon="ka-ta-tahkiskâtin" class="vta" gcat="1s2sTA" preverbs="ka|will dupL|L.REDUP" sgloss="kick" stem="tahkiskaw" suffix="-itin">ka-tah-tahkiskâtin</w>
 !</q>
@@ -4206,7 +4206,7 @@
 <w canon="ka-nipahitin" class="vta" gcat="1s2sTA" preverbs="ka|will" sgloss="kill" stem="nipah" suffix="-itin">ka-nipahitin</w>
 ,
 <w canon="êkâ" class="ipc" gcat="IPC" sgloss="not_to" stem="êkâ">êkâ</w>
-<w canon="kâ-wî-kâ-kitosiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj wî|will dupH|H.REDUP" sgloss="address" stem="kitot" suffix="-iyan">kâ-wê-kâ-kitosiyin</w>
+<w canon="kâ-wî-kâ-kitosiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj wî|will dupH|H.REDUP" sgloss="address" stem="kitot" suffix="-iyan">kâ-wê-kâ-kitosiyan</w>
 !</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .
@@ -4967,7 +4967,7 @@
 
 <seg n="173.3">
 <q>
-<w canon="ê-kî-kitimâkisiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj kî|PAST" sgloss="be_pitiable" stem="kitimâkisi" suffix="-yan">ê-kîh-kitimâkisiyin</w>
+<w canon="ê-kî-kitimâkisiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj kî|PAST" sgloss="be_pitiable" stem="kitimâkisi" suffix="-yan">ê-kîh-kitimâkisiyan</w>
 ,
 <q>
 <w canon="mahti" class="ipc" gcat="IPC" sgloss="let's_see" stem="mahti">mahtih</w>
@@ -5459,7 +5459,7 @@
 <w canon="nisîm" class="nda" gcat="3sNDAof1s" prefix="1" sgloss="younger_sib" stem="sîm" suffix="0">nisîm</w>
 ,
 <w canon="kakwêyâho" class="vai" gcat="2sAIimp" sgloss="hurry" stem="kakwêyâho" suffix="0">kakwêyâhoh</w>
-<w canon="ê-nânapâcihoyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="dress_self_up" stem="nânapâciho" suffix="-yan">êh-nanâpâcihoyin</w>
+<w canon="ê-nânapâcihoyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="dress_self_up" stem="nânapâciho" suffix="-yan">êh-nanâpâcihoyin</w>
 .</q>
 <gloss>“Ho, little sister, hurry and deck yourself out.</gloss>
 </seg>

--- a/source/SSSC/sssc34.xml
+++ b/source/SSSC/sssc34.xml
@@ -768,7 +768,7 @@
 
 <seg n="20.2">
 <q rend="PRE 0 POST0">
-<w canon="kâ-ayisiyinîwiyin" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="be_person" stem="ayisiyinîwi" suffix="-yan">k-âyisiyinîwiyin</w>
+<w canon="kâ-ayisiyinîwiyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="be_person" stem="ayisiyinîwi" suffix="-yan">k-âyisiyinîwiyin</w>
 ,
 <q>
 <w canon="acâhkosak" class="na" gcat="3pNA" sgloss="star" stem="acâhkos" suffix="-ak">acâhkosak</w>
@@ -2212,7 +2212,7 @@
 <w canon="kîhkwahâhkês" class="na" extra="dim" gcat="3sNA" sgloss="wolverine" stem="kîhkwahâhkêw" suffix="0">kîhkwahâkês</w>
 ,
 <w canon="iyikohk" class="ipc" gcat="IPC" sgloss="so_much" stem="iyikohk">iyikohk</w>
-<w canon="kâ-wîsakisimiyin" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="throw_painfully" stem="wîsakisim" suffix="-iyan">kâ-wîsakisimiyin</w>
+<w canon="kâ-wîsakisimiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="throw_painfully" stem="wîsakisim" suffix="-iyan">kâ-wîsakisimiyan</w>
 ,
 <w canon="nitawâc" class="ipc" gcat="IPC" sgloss="despite_all" stem="nitawâc">ntawâc</w>
 <w canon="anima" class="dem" gcat="0sDEM" sgloss="that" stem="anima">anim</w>
@@ -3027,7 +3027,7 @@
 <w canon="misawâc" class="ipc" gcat="IPC" sgloss="in_any_case" stem="misawâc">misawâc</w>
 <w canon="ta-pîhcâw" class="vii" gcat="0sII" preverbs="ta|FUT" sgloss="be_long_distance" stem="pîhcâw" suffix="0">ta-pîhcâw</w>
 <w canon="itê" class="ipc" gcat="IPC" sgloss="there" stem="itê">itêh</w>
-<w canon="cita-itâmoyin" class="vai" gcat="2sAIcnj" preverbs="cita|????" sgloss="flee" stem="itâmo" suffix="-yan">cit-êtâmoyin</w>
+<w canon="cita-itâmoyan" class="vai" gcat="2sAIcnj" preverbs="cita|????" sgloss="flee" stem="itâmo" suffix="-yan">cit-êtâmoyin</w>
 !</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 <w canon="osîma" class="nda" gcat="3oNDAof3s" prefix="3" sgloss="younger_sib" stem="sîm" suffix="-a">osîma</w>
@@ -4954,7 +4954,7 @@
 ,
 <w canon="têyaniya" class="ndi" gcat="0pNDI" sgloss="tongue" stem="têyaniy" suffix="-a">têyaniyah</w>
 <w canon="piko" class="ipc" gcat="IPC" sgloss="only" stem="piko">piko</w>
-<w canon="kita-omîciwiniyin" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="have_food" stem="omîciwini" suffix="-yan">kit-ômîciwiniyin</w>
+<w canon="kita-omîciwiniyan" class="vai" gcat="2sAIcnj" preverbs="kita|to" sgloss="have_food" stem="omîciwini" suffix="-yan">kit-ômîciwiniyin</w>
 ,
 <w canon="ê-isi-takahkêyimitân" class="vta" gcat="1s2sTAcnj" preverbs="ê|cnj isi|thus" sgloss="think_well_of" stem="takahkêyim" suffix="-itân">êy-isi-takahkêyimitân</w>
 ,
@@ -5126,7 +5126,7 @@
 ,
 <w canon="nisîm" class="nda" gcat="3sNDAof1s" prefix="1" sgloss="younger_sib" stem="sîm" suffix="0">nisîm</w>
 ,
-<w canon="ta-kitohtâyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="play_music" stem="kitohtâ" suffix="-yan">ta-kitohtâyin</w>
+<w canon="ta-kitohtâyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="play_music" stem="kitohtâ" suffix="-yan">ta-kitohtâyan</w>
 .</q>
 <gloss>Then, always, when she had put on her finery, “Now, climb up again, little sister, to play on the flute.”</gloss>
 </seg>
@@ -6773,7 +6773,7 @@
 <w canon="awiyak" class="pr" gcat="3sPR" sgloss="someone" stem="awiyak">awiyak</w>
 <w canon="ta-nâtam" class="vti" gcat="3sTI" preverbs="ta|FUT" sgloss="fetch" stem="nât" suffix="-am">ta-nâtam</w>
 ,
-<w canon="ta-minihkwêyin" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="drink" stem="minihkwê" suffix="-yan">ta-minihkwêyin</w>
+<w canon="ta-minihkwêyan" class="vai" gcat="2sAIcnj" preverbs="ta|FUT" sgloss="drink" stem="minihkwê" suffix="-yan">ta-minihkwêyan</w>
 ,</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
 .

--- a/source/SSSC/sssc36.xml
+++ b/source/SSSC/sssc36.xml
@@ -124,7 +124,7 @@
 <q rend="PRE 0 POST1">
 <w canon="êkwêyâk" class="ipc" gcat="IPC" sgloss="exactly_then" stem="êkwêyâk">êkwêyâk</w>
 <w canon="ê-kiskêyihtamân" class="vti" gcat="1sTIcnj" preverbs="ê|cnj" sgloss="know" stem="kiskêyiht" suffix="-amân">ê-kiskêyihtamân</w>
-<w canon="ê-pimâtisiyin" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live" stem="pimâtisi" suffix="-yan">êh-pimâtisiyin</w>
+<w canon="ê-pimâtisiyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="live" stem="pimâtisi" suffix="-yan">êh-pimâtisiyin</w>
 ,</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
 .


### PR DESCRIPTION
Using the following search `(ê-[a-zâêîô\-]*)yin\b` replace `$1yan`.