### PR TITLE
s/kêkway/kîkwây/g

### DIFF
--- a/source/PCT/pct12.xml
+++ b/source/PCT/pct12.xml
@@ -295,7 +295,7 @@
 <w canon="ê-sâkêwêt" class="vai" gcat="3sAIcnj" preverbs="ê|cnj" sgloss="appear" stem="sâkêwê" suffix="-t">ê-sâkêwêt</w>
 ,
 <w canon="ê-wî-kakwê-wâpahtahk" class="vti" gcat="3sTIcnj" preverbs="ê|cnj wî|will kakwê|try_to" sgloss="see" stem="wâpaht" suffix="-ahk">ê-wîh-kakwêh-wâpahtahk</w>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 .
 <gloss>Where a river flowed by, there he went along; concealing himself, but coming forth every now and then, to see what could be seen.</gloss>
 </seg>
@@ -971,7 +971,7 @@
 
 <seg n="16.1">
 <q>
-<w canon="kêkwaya" class="pr" gcat="3o/0pPRq" sgloss="what" stem="kîkway" suffix="-3o/0p">kêkwayah</w>
+<w canon="kîkwâya" class="pr" gcat="3o/0pPRq" sgloss="what" stem="kîkway" suffix="-3o/0p">kêkwayah</w>
 <w canon="kiya" class="pr" gcat="2sPR" sgloss="you" stem="kiya">kiyah</w>
 ?</q>
 <w canon="itinamâk" class="vta" gcat="3o3sTA" sgloss="move_by_hand" stem="itinamaw" suffix="-ik">itinamâk</w>

--- a/source/PCT/pct21.xml
+++ b/source/PCT/pct21.xml
@@ -2326,7 +2326,7 @@
 <w canon="ay" class="ipc" gcat="IPC" sgloss="hey" stem="ay">ây</w>
 ,
 <w canon="êkwa" class="ipc" gcat="IPC" sgloss="then" stem="êkwa">êkwah</w>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="kinitawêyihtên" class="vti" gcat="2sTI" prefix="2" sgloss="want" stem="nitawêyiht" suffix="-ên">kintawêyihtên</w>
 ?</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
@@ -2638,7 +2638,7 @@
 <seg n="78.10">
 <q rend="PRE0 POST1">
 <w canon="êkwa" class="ipc" gcat="IPC" sgloss="then" stem="êkwa">êkwah</w>
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="wâh-otinaman" class="vti" gcat="2sTIcnj" prefix="IC" preverbs="wî|will" sgloss="take" stem="otin" suffix="-aman">wâh-otinaman</w>
 <w canon="ayiwinisa" class="ni" gcat="0oNI" sgloss="clothes" stem="ayiwinis" suffix="-a">ayôwinisah</w>
 ?</q>

--- a/source/PCT/pct24.xml
+++ b/source/PCT/pct24.xml
@@ -1984,7 +1984,7 @@
 
 <seg n="83.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
 <w canon="ê-mawîhkâtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj" sgloss="cry_out_over" stem="mawîhkât" suffix="-aman">êh-mawîhkâtaman</w>
 ?</q>

--- a/source/PCT/pct28.xml
+++ b/source/PCT/pct28.xml
@@ -161,14 +161,14 @@
 
 <seg n="4.3">
 <q rend="PRE 0 POST1">
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="anima" class="dem" gcat="0sDEM" sgloss="that" stem="anima">anima</w>
 :
 <q>
 <w canon="ahpônâni" class="ipc" gcat="IPC" sgloss="of_course_not" stem="ahpônâni">ahpônâni</w>
 <w canon="kîwâc" class="ipc" gcat="IPC" sgloss="failing" stem="kîwâc">kîwâc</w>
 ,</q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="anima" class="dem" gcat="0sDEM" sgloss="that" stem="anima">anim</w>
 <w canon="êwako" class="pr" gcat="PR" sgloss="that_one" stem="êwako">êwakô</w>
 ?</q>
@@ -344,7 +344,7 @@
 <w canon="ê-wîhtamâht" class="vta" gcat="x3sTAcnj" preverbs="ê|cnj" sgloss="tell_about" stem="wîhtamaw" suffix="-iht">êh-wîhtamâht</w>
 <w canon="ana" class="dem" gcat="3sDEM" sgloss="that" stem="ana">ana</w>
 <w canon="osîkinikêw" class="na" gcat="3sNA" sgloss="bartender" stem="osîkinikêw" suffix="0">osîkinikêw</w>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ohci" class="ipc" gcat="IPC" sgloss="thence" stem="ohci">ohci</w>
 <w canon="kâ-minahiwêt" class="vai" gcat="3sAIcnj" preverbs="kâ|cnj" sgloss="give_ppl_drink" stem="minahiwê" suffix="-t">kâ-minahiwêt</w>
 <w canon="awa" class="dem" gcat="3sDEM" sgloss="this" stem="awa">awa</w>

--- a/source/PCT/pct33.xml
+++ b/source/PCT/pct33.xml
@@ -501,7 +501,7 @@
 <w canon="wîcimosa" class="nda" gcat="3oNDAof3s" prefix="3" sgloss="sweetheart" stem="îcimos" suffix="-a">wîcimosah</w>
 ,
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="kâ-nîmâyêk" class="vai" gcat="2pAIcnj" preverbs="kâ|cnj" sgloss="take_provisions" stem="nîmâ" suffix="-yêk">kâ-nîmâyâk</w>
 ?</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>

--- a/source/PCT/pct36.xml
+++ b/source/PCT/pct36.xml
@@ -814,7 +814,7 @@
 ,
 <q>
 <w canon="kîspin" class="ipc" gcat="IPC" sgloss="if" stem="kîspin">kîspin</w>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="sêkihikoyani" class="vta" gcat="0x2sTAsubjunci" sgloss="frighten" stem="sêkih" suffix="-ikoyani">sêkihikoyinih</w>
 ,
 <w canon="kisiwâk" class="ipc" gcat="IPC" sgloss="nearby" stem="kisiwâk">kisiwâk</w>

--- a/source/PCT/pct38.xml
+++ b/source/PCT/pct38.xml
@@ -2805,7 +2805,7 @@
 
 <seg n="83.3">
 <q rend="PRE 0 POST0">
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="êtokê" class="ipc" gcat="IPC" sgloss="I_guess" stem="êtikwê">êtokê</w>
 <w canon="ka-sa-sawêyimâwâwak" class="vta" gcat="2p3pTA" preverbs="ka|will dupL|L.REDUP" sgloss="be_generous_to" stem="sawêyim" suffix="-âwâwak">ka-sa-sawêyimâwâwak</w>
 ,
@@ -2930,7 +2930,7 @@
 
 <seg n="86.2">
 <q rend="PRE0 POST1">
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="êtokê" class="ipc" gcat="IPC" sgloss="I_guess" stem="êtikwê">êtokê</w>
 <w canon="kiyi-oy-ohtinamawak" class="vta" gcat="1s3sTAcnj" preverbs="kiyi|FUT oy|L.REDUP" sgloss="take_from_for" stem="ohtinamaw" suffix="-ak">kiy-ôy-ôhtinamôwak</w>
 ?</q>

--- a/source/PCT/pct41.xml
+++ b/source/PCT/pct41.xml
@@ -2853,7 +2853,7 @@
 
 <seg n="66.2">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
 <w canon="mêwîhkâtaman" class="vti" gcat="2sTIcnj" prefix="IC" sgloss="cry_out_over" stem="mawîhkât" suffix="-aman">mêwihkâtaman</w>
 ?
@@ -3375,7 +3375,7 @@
 ,
 <w canon="nitânis" class="nda" gcat="3sNDAof1s" prefix="1" sgloss="daughter" stem="tânis" suffix="0">ntânis</w>
 ,
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
 <w canon="ê-mawîhkâtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj" sgloss="cry_out_over" stem="mawîhkât" suffix="-aman">ê-mawîhkâtaman</w>
 ?</q>

--- a/source/PCT/pct42.xml
+++ b/source/PCT/pct42.xml
@@ -1270,7 +1270,7 @@
 
 <seg n="36.1">
 <q>
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="mîna" class="ipc" gcat="IPC" sgloss="also" stem="mîna">mîna</w>
 ?</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>
@@ -2935,7 +2935,7 @@
 
 <seg n="91.1">
 <q>
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="ôta" class="ipc" gcat="IPC" sgloss="here" stem="ôta">ôtah</w>
 <w canon="ê-osîhtâyan" class="vai" gcat="2sAIcnj" preverbs="ê|cnj" sgloss="prepare" stem="osîhtâ" suffix="-yan">êw-osîhtâyin</w>
 ?</q>
@@ -2947,7 +2947,7 @@
 
 <seg n="91.2">
 <q>
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="kiyi-osîhtâyan" class="vai" gcat="2sAIcnj" preverbs="kiyi|FUT" sgloss="prepare" stem="osîhtâ" suffix="-yan">kiy-osîhtâyan</w>
 ?</q>
 <gloss>“What is it you mean to do?”</gloss>
@@ -3035,7 +3035,7 @@
 <q><q>
 <w canon="mahti" class="ipc" gcat="IPC" sgloss="let's_see" stem="mahti">mahtih</w>
 <w canon="wâh-wîhtamâtotân" class="vai" gcat="1iAIimp" preverbs="dupH|H.REDUP" sgloss="tell_e.o._about" stem="wîhtamâto" suffix="-tân">wâh-wîhtamâtotân</w>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="kita-isi-kî-ohci-nipahikawiyahk" class="vta" gcat="x1iTAcnj" preverbs="kita|to isi|thus kî|can ohci|thence" sgloss="kill" stem="nipah" suffix="-ikawiyahk">kit-si-ki-ohci-nipahikawiyahk</w>
 ,</q>
 <w canon="kika-itânaw" class="vta" gcat="1i3sTA" prefix="2" preverbs="ka|will" sgloss="say_to" stem="it" suffix="-ânaw">kik-êtânâw</w>

--- a/source/PCT/pct44.xml
+++ b/source/PCT/pct44.xml
@@ -653,7 +653,7 @@
 ,
 <w canon="ê-nîpihk" class="vii" gcat="0sIIcnj" preverbs="ê|cnj" sgloss="be_summer" stem="nîpin" suffix="-k">êh-nîpihk</w>
 ,
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 ?
 -
 <gloss>hen, at one time, as he was walking along, in summer, what was that? --</gloss>
@@ -1217,7 +1217,7 @@
 <w canon="sîsîp" class="na" gcat="3sNA" sgloss="duck" stem="sîsîp" suffix="0">sîsîp</w>
 ,
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="kâ-nayahtaman" class="vti" gcat="2sTIcnj" preverbs="kâ|cnj" sgloss="carry_on_back" stem="nayaht" suffix="-aman">kâ-nayahtaman</w>
 ?</q>
 <gloss>“Big Brother,” said a duck, “what are you carrying on your back?”</gloss>
@@ -2476,7 +2476,7 @@
 
 <seg n="90.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="kiya" class="pr" gcat="2sPR" sgloss="you" stem="kiya">kiya</w>
 <w canon="mistik" class="na" gcat="3sNA" sgloss="tree" stem="mistikw" suffix="0">mistik</w>
 ?</q>
@@ -2531,7 +2531,7 @@
 
 <seg n="94.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ê-itikawiyan" class="vta" gcat="x2sTAcnj" preverbs="ê|cnj" sgloss="say_to" stem="it" suffix="-ikawiyan">h-itikôwiyan</w>
 ?</q>
 <gloss>“What are you called?”</gloss>
@@ -3404,7 +3404,7 @@
 
 <seg n="124.1">
 <q rend="PRE 1 POST0">
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="êtokê" class="ipc" gcat="IPC" sgloss="I_guess" stem="êtikwê">êtokê</w>
 <w canon="ayîsiyiniwa" class="na" gcat="3oNA" sgloss="person" stem="ayisiyiniw" suffix="-a">ayîsiyiniwah</w>
 <w canon="kê-nôtinitoyit" class="vai" gcat="3oAIcnj" preverbs="kê|IC+FUT" sgloss="fight_with_e.o." stem="nôtinito" suffix="-yit">kê-nôtinitôwit</w>

--- a/source/SSSC/sssc01.xml
+++ b/source/SSSC/sssc01.xml
@@ -471,7 +471,7 @@
 <q>
 <w canon="hwâ" class="interj" gcat="INTERJ" sgloss="oh" stem="hwâ">hwah</w>
 ,
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
 ,</q>
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">itwêw</w>
@@ -2249,7 +2249,7 @@
 
 <seg n="77.1">
 <q rend="PRE 1 POST0">
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="kâ-saskitêk" class="vii" gcat="0sIIcnj" preverbs="kâ|cnj" sgloss="catch_fire" stem="saskitê" suffix="-k">kâ-saskitêk</w>
 ?</q>
 <gloss>“What is burning?</gloss>
@@ -2592,7 +2592,7 @@
 
 <seg n="91.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="kâ-kîsitêk" class="vii" gcat="0sIIcnj" preverbs="kâ|cnj" sgloss="be_burnt" stem="kîsitê" suffix="-k">kâ-kîsitêk</w>
 ?</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
@@ -3029,7 +3029,7 @@
 
 <seg n="108.1">
 <q rend="PRE 1 POST0">
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="itahk" class="vti" gcat="3sTIcnj" sgloss="say_about" stem="it" suffix="-ahk">itahk</w>
 <w canon="ayîkis" class="na" gcat="3sNA" sgloss="frog" stem="ayîkis" suffix="0">ayîkis</w>
 <w canon="kê-nipiskêt" class="vai" gcat="3sAIcnj" preverbs="kê|IC+FUT" sgloss="doctor_by_breathing" stem="nipiskê" suffix="-t">kê-nipiskêt</w>

--- a/source/SSSC/sssc04.xml
+++ b/source/SSSC/sssc04.xml
@@ -67,7 +67,7 @@
 ;
 <w canon="nama" class="ipc" gcat="IPC" sgloss="not" stem="nama">nama</w>
 <w canon="wiya" class="ipc" gcat="IPC" sgloss="WIYA" stem="wiya">wya</w>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="otayôwinis" class="ni" gcat="0sNIof3s" prefix="3" sgloss="clothes" stem="ayiwinis" suffix="0">otayôwinis</w>
 <w canon="ê-wîkicik" class="vai" gcat="3pAIcnj" preverbs="ê|cnj" sgloss="live_there" stem="wîki" suffix="-cik">ê-wîkicik</w>
 ,
@@ -199,7 +199,7 @@
 <w canon="wêmistikôsiwak" class="na" gcat="3pNA" sgloss="French_person" stem="wêmistikôsiw" suffix="-ak">wêmistikôsiwak</w>
 -
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="kinitawêyihtên" class="vti" gcat="2sTI" prefix="2" sgloss="want" stem="nitawêyiht" suffix="-ên">kintawêyihtên</w>
 ,
 <w canon="wîsahkêcâhk" class="na" gcat="3sNA" sgloss="Wisahketchahk" stem="wîsahkêcâhkw" suffix="0">wîsahkêcâhk</w>

--- a/source/SSSC/sssc06.xml
+++ b/source/SSSC/sssc06.xml
@@ -173,7 +173,7 @@
 
 <seg n="4.2">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="kâ-nayahtahk" class="vti" gcat="3sTIcnj" preverbs="kâ|cnj" sgloss="carry_on_back" stem="nayaht" suffix="-ahk">kâ-nayahtahk</w>
 ?</q>
 <w canon="êkosi" class="ipc" gcat="IPC" sgloss="thus" stem="êkosi">êkosi</w>
@@ -216,7 +216,7 @@
 <q>
 <w canon="nistêsê" class="nda" extra="voc" gcat="3sNDAof1svoc" prefix="1" sgloss="older_brother" stem="stês">nistêsê</w>
 ,
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="kâ-nayahtaman" class="vti" gcat="2sTIcnj" preverbs="kâ|cnj" sgloss="carry_on_back" stem="nayaht" suffix="-aman">kâ-nayahtaman</w>
 ?</q>
 <gloss>“Big brother, what is that you're carrying on your back?”</gloss>
@@ -254,7 +254,7 @@
 <q>
 <w canon="nistêsê" class="nda" extra="voc" gcat="3sNDAof1svoc" prefix="1" sgloss="older_brother" stem="stês">nistêsê</w>
 ,
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="kâ-nayahtaman" class="vti" gcat="2sTIcnj" preverbs="kâ|cnj" sgloss="carry_on_back" stem="nayaht" suffix="-aman">kâ-nayahtaman</w>
 ?</q>
 <gloss>Again the duck asked him, “Big brother, what is it you're carrying on your back?”</gloss>
@@ -281,7 +281,7 @@
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">itwêw</w>
 ,
 <q>
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="kâ-nayahtaman" class="vti" gcat="2sTIcnj" preverbs="kâ|cnj" sgloss="carry_on_back" stem="nayaht" suffix="-aman">kâ-nayahtaman</w>
 ?</q>
 <gloss>“Say,” it said, “what is it you're carrying?”</gloss>
@@ -307,7 +307,7 @@
 
 <seg n="13.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="pasakwâpisimôwin" class="ni" gcat="0sNI" sgloss="shut_eye_dance" stem="pasakwâpisimowin" suffix="0">pasakwâpisimôwin</w>
 ?</q>
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">itwêw</w>
@@ -915,7 +915,7 @@
 <w canon="wîsahkêcâhk" class="na" gcat="3sNA" sgloss="Wisahketchahk" stem="wîsahkêcâhkw" suffix="0">wîsahkêcâhk</w>
 :
 <q rend="PRE 1 POST0">
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
 <w canon="ita" class="ipc" gcat="IPC" sgloss="there" stem="ita">itah</w>
 <w canon="kê-pêtâyân" class="vai" gcat="1sAIcnj" preverbs="kê|IC+FUT" sgloss="bring" stem="pêtâ" suffix="-yân">kê-pêtâyân</w>

--- a/source/SSSC/sssc11.xml
+++ b/source/SSSC/sssc11.xml
@@ -827,10 +827,10 @@
 
 <seg n="16.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="kê-âpacihtâyahk" class="vai" gcat="1iAIcnj" preverbs="kê|IC+FUT" sgloss="use" stem="âpacihtâ" suffix="-yahk">kêy-âpacihtâyahk</w>
 <w canon="ta-pimiwitâyahk" class="vai" gcat="1iAIcnj" preverbs="ta|FUT" sgloss="carry" stem="pimiwitâ" suffix="-yahk">ta-pimiwitâyahk</w>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 ?</q>
 <gloss>“But what are we to use to carry things?”</gloss>
 </seg>

--- a/source/SSSC/sssc17.xml
+++ b/source/SSSC/sssc17.xml
@@ -1867,7 +1867,7 @@
 
 <seg n="45.2">
 <q rend="PRE 0 POST0">
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="kê-postayôwinisêt" class="vai" gcat="3sAIcnj" preverbs="kê|IC+FUT" sgloss="put_on_clothes" stem="postayôwinisê" suffix="-t">kê-postayôwinisêt</w>
 ?</q>
 <gloss>What is he to wear?</gloss>

--- a/source/SSSC/sssc18.xml
+++ b/source/SSSC/sssc18.xml
@@ -625,7 +625,7 @@
 ,
 <q>
 <w canon="mahti" class="ipc" gcat="IPC" sgloss="let's_see" stem="mahti">mahtih</w>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
 <w canon="ita" class="ipc" gcat="IPC" sgloss="there" stem="ita">itah</w>
 <w canon="ê-ayât" class="vai" gcat="3sAIcnj" preverbs="ê|cnj" sgloss="be" stem="ayâ" suffix="-t">êh-ayât</w>
@@ -2045,7 +2045,7 @@
 
 <seg n="75.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="êtokê" class="ipc" gcat="IPC" sgloss="I_guess" stem="êtikwê">êtokê</w>
 <w canon="kê-nipahtât" class="vai" gcat="3sAIcnj" preverbs="kê|IC+FUT" sgloss="kill" stem="nipahtâ" suffix="-t">kê-nipahtât</w>
 !</q>
@@ -3068,7 +3068,7 @@
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">îtêw</w>
 :
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="mîna" class="ipc" gcat="IPC" sgloss="also" stem="mîna">mînah</w>
 <w canon="kâ-wî-atamihit" class="vta" gcat="3s1sTAcnj" preverbs="kâ|cnj wî|will" sgloss="make_grateful" stem="atamih" suffix="-it">kâ-wîh-atamihit</w>
 ?</q>
@@ -4294,7 +4294,7 @@
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">îtwêw</w>
 :
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="mîna" class="ipc" gcat="IPC" sgloss="also" stem="mîna">mînah</w>
 <w canon="kâ-wî-atamihit" class="vta" gcat="3s1sTAcnj" preverbs="kâ|cnj wî|will" sgloss="make_grateful" stem="atamih" suffix="-it">kâ-wîh-atamihit</w>
 <w canon="niwîkimâkan" class="nda" gcat="3sNDAof1s" prefix="1" sgloss="spouse" stem="wîkimâkan" suffix="0">niwîkimâkan</w>

--- a/source/SSSC/sssc19.xml
+++ b/source/SSSC/sssc19.xml
@@ -1167,7 +1167,7 @@
 
 <seg n="18.1">
 <q>
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="awa" class="dem" gcat="3sDEM" sgloss="this" stem="awa">awa</w>
 ?</q>
 <w canon="itêyihtam" class="vti" gcat="3sTI" sgloss="think_of" stem="itêyiht" suffix="-am">itêyihtam</w>
@@ -1196,7 +1196,7 @@
 
 <seg n="20.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="awa" class="dem" gcat="3sDEM" sgloss="this" stem="awa">awa</w>
 ?</q>
 <w canon="itêyihtam" class="vti" gcat="3sTI" sgloss="think_of" stem="itêyiht" suffix="-am">itêyihtam</w>
@@ -1609,7 +1609,7 @@
 <w canon="ê-pêsiwâyit" class="vta" gcat="3o3oTAcnj" preverbs="ê|cnj" sgloss="bring_hither" stem="pêsiw" suffix="-âyit">êh-pêsiwâyit</w>
 ,
 <q>
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="êtokê" class="ipc" gcat="IPC" sgloss="I_guess" stem="êtikwê">êtokê</w>
 ?</q>
 <w canon="ê-itêyihtahk" class="vti" gcat="3sTIcnj" preverbs="ê|cnj" sgloss="think_of" stem="itêyiht" suffix="-ahk">êh-itêyihtahk</w>
@@ -2272,7 +2272,7 @@
 <w canon="êkosi" class="ipc" gcat="IPC" sgloss="thus" stem="êkosi">êkosi</w>
 ,
 <q>
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="êtokê" class="ipc" gcat="IPC" sgloss="I_guess" stem="êtikwê">êtokê</w>
 ?</q>
 <w canon="itêyihtam" class="vti" gcat="3sTI" sgloss="think_of" stem="itêyiht" suffix="-am">itêyihtam</w>
@@ -4700,7 +4700,7 @@
 
 <seg n="112.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">oma</w>
 <w canon="mâna" class="ipc" gcat="IPC" sgloss="usually" stem="mâna">mâna</w>
 <w canon="ê-nâtamêk" class="vti" gcat="2pTIcnj" preverbs="ê|cnj" sgloss="fetch" stem="nât" suffix="-amêk">êh-nâtamêk</w>

--- a/source/SSSC/sssc20.xml
+++ b/source/SSSC/sssc20.xml
@@ -792,7 +792,7 @@
 <w canon="otâpakwâna" class="ni" gcat="0pNIof3s" prefix="3" sgloss="snare" stem="tâpakwân" suffix="-a">otâpakwâna</w>
 ,
 <w canon="nama" class="ipc" gcat="IPC" sgloss="not" stem="nama">nama</w>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="nipahtâw" class="vai" gcat="3sAI" sgloss="kill" stem="nipahtâ" suffix="-w">nipahtâw</w>
 .
 <gloss>The next morning, when she went to her snares, she had not killed anything.</gloss>

--- a/source/SSSC/sssc21.xml
+++ b/source/SSSC/sssc21.xml
@@ -492,7 +492,7 @@
 
 <seg n="14.3">
 <q>
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="kî-asamâyahk" class="vta" gcat="1i3sTAcnj" preverbs="kî|can" sgloss="feed" stem="asam" suffix="-âyahk">kiy-âsamâyahk</w>
 ?
 <w canon="piko" class="ipc" gcat="IPC" sgloss="only" stem="piko">pikoh</w>
@@ -1972,7 +1972,7 @@
 <seg n="57.2">
 <w canon="namôya" class="ipc" gcat="IPC" sgloss="not" stem="namôya">namoya</w>
 <w canon="kiskêyihtam" class="vti" gcat="3sTI" sgloss="know" stem="kiskêyiht" suffix="-am">kiskêyihtam</w>
-<w canon="kêkwaya" class="pr" gcat="3o/0pPRq" sgloss="what" stem="kîkway" suffix="-3o/0p">kêkwayah</w>
+<w canon="kîkwâya" class="pr" gcat="3o/0pPRq" sgloss="what" stem="kîkway" suffix="-3o/0p">kêkwayah</w>
 <w canon="ôhi" class="dem" gcat="0pDEM" sgloss="this" stem="ôma" suffix="-0p">ôhi</w>
 <w canon="awa" class="dem" gcat="3sDEM" sgloss="this" stem="awa">awa</w>
 <w canon="awâsis" class="na" gcat="3sNA" sgloss="child" stem="awâsis" suffix="0">êwêsis</w>
@@ -2230,7 +2230,7 @@
 
 <seg n="63.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="awa" class="dem" gcat="3sDEM" sgloss="this" stem="awa">awa</w>
 ,
 <w canon="nôsisê" class="nda" extra="voc" gcat="3sNDAof1svoc" prefix="1" sgloss="grandchild" stem="ôsisim">nôsisê</w>
@@ -2638,7 +2638,7 @@
 <q>
 <w canon="nôhkô" class="nda" extra="voc" gcat="3sNDAof1svoc" prefix="1" sgloss="grandmother" stem="ôhkom">nôhkô</w>
 ,
-<w canon="kêkwaya" class="pr" gcat="0pPRq" sgloss="what" stem="kîkway" suffix="-0p">kêkwayah</w>
+<w canon="kîkwâya" class="pr" gcat="0pPRq" sgloss="what" stem="kîkway" suffix="-0p">kêkwayah</w>
 <w canon="ôhi" class="dem" gcat="0pDEM" sgloss="this" stem="ôma" suffix="-0p">ôhi</w>
 ?</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
@@ -2676,7 +2676,7 @@
 <seg n="76.1">
 <w canon="namôya" class="ipc" gcat="IPC" sgloss="not" stem="namôya">namoya</w>
 <w canon="wî-wîhtamawêw" class="vta" gcat="3s3oTA" preverbs="wî|will" sgloss="tell_about" stem="wîhtamaw" suffix="-êw">wîh-wîhtamawêw</w>
-<w canon="kêkwaya" class="pr" gcat="0pPRq" sgloss="what" stem="kîkway" suffix="-0p">kêkwayah</w>
+<w canon="kîkwâya" class="pr" gcat="0pPRq" sgloss="what" stem="kîkway" suffix="-0p">kêkwayah</w>
 <w canon="ôhi" class="dem" gcat="0pDEM" sgloss="this" stem="ôma" suffix="-0p">ôhi</w>
 <w canon="kâ-asiwatêyiki" class="vii" gcat="0qIIcnj" preverbs="kâ|cnj" sgloss="be_placed_inside" stem="asiwatê" suffix="-yiki">k-âsiwatêyikih</w>
 .
@@ -2855,7 +2855,7 @@
 
 <seg n="78.1">
 <q>
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="awa" class="dem" gcat="3sDEM" sgloss="this" stem="awa">awa</w>
 <w canon="kâ-wî-ayâtamihit" class="vta" gcat="3s1sTAcnj" preverbs="kâ|cnj wî|will" sgloss="please" stem="ayâtamih" suffix="-it">kâ-wih-ayâtamihit</w>
 <w canon="nôsisimis" class="nda" extra="dim" gcat="3sNDAof1s" prefix="1" sgloss="grandchild" stem="ôsisim" suffix="0">nôsisimis</w>
@@ -3112,7 +3112,7 @@
 
 <seg n="88.1">
 <q>
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="awa" class="dem" gcat="3sDEM" sgloss="this" stem="awa">awa</w>
 <w canon="kâ-wî-atamihit" class="vta" gcat="3s1sTAcnj" preverbs="kâ|cnj wî|will" sgloss="make_grateful" stem="atamih" suffix="-it">kâ-wîh-atamihit</w>
 <w canon="nôsisim" class="nda" gcat="3sNDAof1s" prefix="1" sgloss="grandchild" stem="ôsisim" suffix="0">nôsisim</w>
@@ -3463,7 +3463,7 @@
 <q>
 <w canon="yahâ" class="interj" gcat="INTERJ" sgloss="yah" stem="yahâ">yahâ</w>
 ,
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="mâka" class="ipc" gcat="IPC" sgloss="but" stem="mâka">mâka</w>
 <w canon="kâ-kî-asamâyahk" class="vta" gcat="1i3sTAcnj" preverbs="kâ|cnj kî|can" sgloss="feed" stem="asam" suffix="-âyahk">kî-kîh-asamayah</w>
 ?</q>

--- a/source/SSSC/sssc22.xml
+++ b/source/SSSC/sssc22.xml
@@ -275,7 +275,7 @@
 <w canon="itwêw" class="vai" gcat="3sAI" sgloss="say" stem="itwê" suffix="-w">îtwêw</w>
 :
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ê-papâ-nâtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj papâ|around" sgloss="fetch" stem="nât" suffix="-aman">êh-papâ-nâtaman</w>
 ,
 <w canon="kâ-papâmohtêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj" sgloss="walk_about" stem="papâmohtê" suffix="-yan">kâ-papâmohtêyan</w>
@@ -990,7 +990,7 @@
 
 <seg n="26.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="mâka" class="ipc" gcat="IPC" sgloss="but" stem="mâka">mâka</w>
 <w canon="kâ-ohci-papâmohtêyan" class="vai" gcat="2sAIcnj" preverbs="kâ|cnj ohci|thence" sgloss="walk_about" stem="papâmohtê" suffix="-yan">kâ-ohci-papâmohtêyan</w>
 ?</q>
@@ -1391,7 +1391,7 @@
 
 <seg n="32.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ê-papâ-nâtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj papâ|around" sgloss="fetch" stem="nât" suffix="-aman">ê-papâ-nâtaman</w>
 ?</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>
@@ -2749,7 +2749,7 @@
 <w canon="oskinîkiw" class="na" gcat="3sNA" sgloss="young_man" stem="oskinîkiw" suffix="0">oskinîkiw</w>
 ,
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
 <w canon="ê-papâ-nâtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj papâ|around" sgloss="fetch" stem="nât" suffix="-aman">ê-papâ-nâtaman</w>
 ?</q>
@@ -5337,7 +5337,7 @@
 <q>
 <w canon="hêy" class="ipc" gcat="IPC" sgloss="hey" stem="hêy">hêy</w>
 ,
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">om</w>
 <w canon="ê-papâ-nâtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj papâ|around" sgloss="fetch" stem="nât" suffix="-aman">êh-papâ-nâtaman</w>
 ?</q>
@@ -6011,7 +6011,7 @@
 <q>
 <w canon="hêy" class="ipc" gcat="IPC" sgloss="hey" stem="hêy">hêy</w>
 ,
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
 <w canon="ê-kî-nâtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj kî|PAST" sgloss="fetch" stem="nât" suffix="-aman">ê-kîh-nâtaman</w>
 ,
@@ -7169,7 +7169,7 @@
 
 <seg n="248.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="mâka" class="ipc" gcat="IPC" sgloss="but" stem="mâka">mâka</w>
 <w canon="ê-papâ-nâtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj papâ|around" sgloss="fetch" stem="nât" suffix="-aman">ê-papâ-nâtaman</w>
 ?</q>

--- a/source/SSSC/sssc24.xml
+++ b/source/SSSC/sssc24.xml
@@ -379,7 +379,7 @@
 <w canon="ê-apit" class="vai" gcat="3sAIcnj" preverbs="ê|cnj" sgloss="sit" stem="api" suffix="-t">êh-apit</w>
 ,
 <w canon="kîtahtawê" class="ipc" gcat="IPC" sgloss="at_times" stem="kêtahtawê">kîtahtawê</w>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="kâ-kiskêyihtahk" class="vti" gcat="3sTIcnj" preverbs="kâ|cnj" sgloss="know" stem="kiskêyiht" suffix="-ahk">kâ-kiskêyihtahk</w>
 <w canon="itâmihk" class="ipc" gcat="IPC" sgloss="beneath" stem="itâmihk">itâmihk</w>
 <w canon="ê-astêyiki" class="vii" gcat="0qIIcnj" preverbs="ê|cnj" sgloss="be_placed" stem="astê" suffix="-yiki">êh-astêyikih</w>

--- a/source/SSSC/sssc26.xml
+++ b/source/SSSC/sssc26.xml
@@ -2323,7 +2323,7 @@
 <q>
 <w canon="ô" class="interj" gcat="INTERJ" sgloss="oh" stem="ô">ôh</w>
 ,
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ita" class="ipc" gcat="IPC" sgloss="there" stem="ita">itah</w>
 <w canon="kê-kitimâkêyimikoyan" class="vta" gcat="0x2sTAcnji" preverbs="kê|IC+FUT" sgloss="pity" stem="kitimâkêyim" suffix="-ikoyan">kê-kitimâkêyimikoyan</w>
 ?</q>

--- a/source/SSSC/sssc28.xml
+++ b/source/SSSC/sssc28.xml
@@ -7045,7 +7045,7 @@
 
 <seg n="162.2">
 <q rend="PRE 0 POST1">
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ohci" class="ipc" gcat="IPC" sgloss="thence" stem="ohci">ohci</w>
 ?</q>
 <w canon="itêw" class="vta" gcat="3s3oTA" sgloss="say_to" stem="it" suffix="-êw">itêw</w>

--- a/source/SSSC/sssc32.xml
+++ b/source/SSSC/sssc32.xml
@@ -1200,7 +1200,7 @@
 <w canon="sihkihp" class="na" gcat="3sNA" sgloss="diver_duck" stem="sihkihp" suffix="0">sihkihp</w>
 ,
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="mâka" class="ipc" gcat="IPC" sgloss="but" stem="mâka">mâka</w>
 <w canon="kiyi-otakohpiyân" class="vai" gcat="1sAIcnj" preverbs="kiyi|FUT" sgloss="have_blanket" stem="otakohpi" suffix="-yân">kiy-ôtakohpiyân</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>
@@ -1236,7 +1236,7 @@
 <q>
 <w canon="yaw" class="ipc" gcat="IPC" sgloss="well_now" stem="yaw">yaw</w>
 ,
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="mâka" class="ipc" gcat="IPC" sgloss="but" stem="mâka">mâka</w>
 <w canon="kiyi-owîkohkiyân" class="vai" gcat="1sAIcnj" preverbs="kiyi|FUT" sgloss="have_kidney_fat" stem="owîkohki" suffix="-yân">kiy-ôwîkohkêyân</w>
 ?</q>
@@ -1263,7 +1263,7 @@
 <q>
 <w canon="yôhô" class="ipc" gcat="IPC" sgloss="oh" stem="yôhô">yôhô</w>
 ,
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="mâka" class="ipc" gcat="IPC" sgloss="but" stem="mâka">mâka</w>
 <w canon="kiyi-otastotiniyân" class="vai" gcat="1sAIcnj" preverbs="kiyi|FUT" sgloss="have_hat" stem="otastotini" suffix="-yân">kiy-ôtastotiniyân</w>
 <w canon="ôma" class="dem" gcat="0sDEM" sgloss="this" stem="ôma">ôma</w>

--- a/source/SSSC/sssc36.xml
+++ b/source/SSSC/sssc36.xml
@@ -399,7 +399,7 @@
 
 <seg n="12.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 ,
 <w canon="kâ-tipêyimiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="own" stem="tipêyim" suffix="-iyan">kâ-tipêyimiyan</w>
 ?</q>
@@ -551,7 +551,7 @@
 
 <seg n="19.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="nitawêyihtaman" class="vti" gcat="2sTIcnj" sgloss="want" stem="nitawêyiht" suffix="-aman">nitawêyihtaman</w>
 ,
 <w canon="kâ-tipêyimiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="own" stem="tipêyim" suffix="-iyan">kâ-tipêyimiyan</w>
@@ -959,7 +959,7 @@
 <w canon="ê-waskawît" class="vai" gcat="3sAIcnj" preverbs="ê|cnj" sgloss="move" stem="waskawî" suffix="-t">êh-waskawît</w>
 ,
 <q>
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 ,
 <w canon="kâ-tipêyimiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="own" stem="tipêyim" suffix="-iyan">kâ-tipêyimiyan</w>
 ,
@@ -1130,7 +1130,7 @@
 
 <seg n="43.1">
 <q>
-<w canon="kîkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kîkway</w>
 <w canon="ê-nitawêyihtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj" sgloss="want" stem="nitawêyiht" suffix="-aman">êh-ntawêyihtaman</w>
 ,
 <w canon="kâ-tipêyimiyan" class="vta" gcat="2s1sTAcnj" preverbs="kâ|cnj" sgloss="own" stem="tipêyim" suffix="-iyan">kâ-tipêyimiyan</w>
@@ -1383,7 +1383,7 @@
 
 <seg n="54.1">
 <q>
-<w canon="kêkway" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
+<w canon="kîkwây" class="pr" gcat="0sPRq" sgloss="what" stem="kîkway">kêkway</w>
 <w canon="ê-nitawêyihtaman" class="vti" gcat="2sTIcnj" preverbs="ê|cnj" sgloss="want" stem="nitawêyiht" suffix="-aman">êh-ntawêyihtaman</w>
 ?</q>
 <w canon="itik" class="vta" gcat="3o3sTA" sgloss="say_to" stem="it" suffix="-ik">itik</w>


### PR DESCRIPTION
If we do this PR first, then the other one we should be good. Changes `kêkway` (what) to `kîkwây` (including a couple plural instances). I used the `sgloss="what"` as a guide to help differentiate the typos of where he meant `kêkway` but put `kîkway` by mistake. 