### PR TITLE
created bulk parse script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "bloomfield",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "xmldoc": "^1.3.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "node_modules/xmldoc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-1.3.0.tgz",
+      "integrity": "sha512-y7IRWW6PvEnYQZNZFMRLNJw+p3pezM4nKYPfr15g4OOW9i8VpeydycFuipE2297OvZnh3jSb2pxOt9QpkZUVng==",
+      "dependencies": {
+        "sax": "^1.2.4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "xmldoc": "^1.3.0"
+  }
+}

--- a/scripts/bulk-parse.js
+++ b/scripts/bulk-parse.js
@@ -56,7 +56,7 @@ const bulkParse = (input, output) => {
     let outputCount = 1;
 
     files.forEach((file) => {
-      let fileName = `json-pct-${outputCount}.json`;
+      let fileName = `pct-${outputCount}.json`;
       let fileOutPath = path.join(output, fileName);
 
       parser(path.join(input, file.name)).then((result) => {

--- a/scripts/bulk-parse.js
+++ b/scripts/bulk-parse.js
@@ -13,7 +13,7 @@ const bulkParse = (input, output) => {
     }
 
     if (!fs.existsSync(output)) {
-        fs.mkdir(output);
+        fs.mkdirSync(output);
     } else {
         fs.readdir(output, (err, files) => {
             if (err) throw new Error(err);

--- a/scripts/bulk-parse.js
+++ b/scripts/bulk-parse.js
@@ -7,8 +7,20 @@ const DEFAULT_INPUT_DIR = `./source/PCT`;
 const DEFAULT_OUTPUT_DIR = `./json`;
 
 const bulkParse = (input, output) => {
+  const helpText = `
+  Usage: 
+    node bulk-parse.js [inputDir] [outputDir]
+
+    inputDir: The directory containing the XML files to be parsed. Defaults to ${ DEFAULT_INPUT_DIR }.
+    outputDir: The directory where the parsed JSON files will be written. Defaults to ${ DEFAULT_OUTPUT_DIR }.
+  `
   const inputDir = process.argv[2];
   const outputDir = process.argv[3];
+
+  if (process.argv[2] == "--help" || process.argv[2] == "-h") {
+    console.log(helpText);
+    process.exit(0);
+  }
 
   if (!inputDir) {
     console.log(`No input directory specified. Using default ${ DEFAULT_INPUT_DIR }`);

--- a/scripts/bulk-parse.js
+++ b/scripts/bulk-parse.js
@@ -1,62 +1,67 @@
-const parser = require('./parse-json.js');
-const fs = require('fs');
-const util = require('util');
-const path = require('path');
-
+const fs = require("fs");
+const util = require("util");
+const path = require("path");
+const parser = require("./parse-json");
 
 const DEFAULT_INPUT_DIR = `./source/PCT`;
 const DEFAULT_OUTPUT_DIR = `./json`;
 
 const bulkParse = (input, output) => {
-    if (!fs.existsSync(input) ) {
-        throw new Error(`${input} directory could not be found or opened.`);
-    }
+  const HELP_MESSAGE = `
+    Usage:
+        node ./scripts/bulk-parse.js [input]
+    `;
 
-    if (!fs.existsSync(output)) {
-        fs.mkdirSync(output);
-    } else {
-        fs.readdir(output, (err, files) => {
-            if (err) throw new Error(err);
+  const inputDir = process.argv[2];
+  if (!inputDir) {
+    console.log(HELP_MESSAGE);
+    process.exit(1);
+  }
 
-            files.forEach((file) => {
-                fs.unlink(path.join(output, file), (err) => {
-                    if (err) {
-                        throw new Error(err);
-                    } 
-                });
-            })
-        })
-    }
+  if (!fs.existsSync(input)) {
+    throw new Error(`${input} directory could not be found or opened.`);
+  }
 
-    fs.readdir(input, { withFileTypes: true }, (err, files) => {
-        if (err) throw new Error(err);
+  if (!fs.existsSync(output)) {
+    fs.mkdirSync(output);
+  } else {
+    fs.readdir(output, (error, files) => {
+      if (error) throw error;
 
-        let outputCount = 1;
+      files.forEach((file) => {
+        fs.unlink(path.join(output, file), (err) => {
+          if (err) {
+            throw new Error(err);
+          }
+        });
+      });
+    });
+  }
 
-        files.forEach((file) => {
-            let fileName = `json-pct-${outputCount}.json`;
-            let fileOutPath = path.join(output, fileName);
-            
-            parser(path.join(input, file.name)).then((result) => {
-                fs.writeFile(fileOutPath, result, (err) => {
-                    if (err) { 
-                        throw new Error(err);
-                    }
-                });
-            });
+  fs.readdir(input, { withFileTypes: true }, (err, files) => {
+    if (err) throw new Error(err);
 
-            outputCount++;
-        })
-    })
+    let outputCount = 1;
+
+    files.forEach((file) => {
+      let fileName = `json-pct-${outputCount}.json`;
+      let fileOutPath = path.join(output, fileName);
+
+      parser(path.join(input, file.name)).then((result) => {
+        fs.writeFile(fileOutPath, result, (err) => {
+          if (err) {
+            throw new Error(err);
+          }
+        });
+      });
+
+      outputCount++;
+    });
+  });
 };
 
 const main = async (input = DEFAULT_INPUT_DIR, output = DEFAULT_OUTPUT_DIR) => {
-    try {
-        bulkParse(input, output);
-    } catch (err) {
-        console.error("ERROR BULK PARSING... NOT OK")
-        console.error(err);
-    }
-}
+  bulkParse(input, output);
+};
 
-main(process.argv[2])
+main(process.argv[2]);

--- a/scripts/bulk-parse.js
+++ b/scripts/bulk-parse.js
@@ -7,16 +7,16 @@ const DEFAULT_INPUT_DIR = `./source/PCT`;
 const DEFAULT_OUTPUT_DIR = `./json`;
 
 const bulkParse = (input, output) => {
-  const HELP_MESSAGE = `
-    Usage:
-        node ./scripts/bulk-parse.js [input]
-    `;
-
   const inputDir = process.argv[2];
+  const outputDir = process.argv[3];
+
   if (!inputDir) {
-    console.log(HELP_MESSAGE);
-    process.exit(1);
-  }
+    console.log(`No input directory specified. Using default ${ DEFAULT_INPUT_DIR }`);
+  };
+
+  if (!outputDir) {
+    console.log(`No output directory specified. Using default ${ DEFAULT_OUTPUT_DIR }`);
+  };
 
   if (!fs.existsSync(input)) {
     throw new Error(`${input} directory could not be found or opened.`);
@@ -64,4 +64,4 @@ const main = async (input = DEFAULT_INPUT_DIR, output = DEFAULT_OUTPUT_DIR) => {
   bulkParse(input, output);
 };
 
-main(process.argv[2]);
+main(process.argv[3]);

--- a/scripts/bulk-parse.js
+++ b/scripts/bulk-parse.js
@@ -1,0 +1,62 @@
+const parser = require('./parse-json.js');
+const fs = require('fs');
+const util = require('util');
+const path = require('path');
+
+
+const DEFAULT_INPUT_DIR = `./source/PCT`;
+const DEFAULT_OUTPUT_DIR = `./json`;
+
+const bulkParse = (input, output) => {
+    if (!fs.existsSync(input) ) {
+        throw new Error(`${input} directory could not be found or opened.`);
+    }
+
+    if (!fs.existsSync(output)) {
+        fs.mkdir(output);
+    } else {
+        fs.readdir(output, (err, files) => {
+            if (err) throw new Error(err);
+
+            files.forEach((file) => {
+                fs.unlink(path.join(output, file), (err) => {
+                    if (err) {
+                        throw new Error(err);
+                    } 
+                });
+            })
+        })
+    }
+
+    fs.readdir(input, { withFileTypes: true }, (err, files) => {
+        if (err) throw new Error(err);
+
+        let outputCount = 1;
+
+        files.forEach((file) => {
+            let fileName = `json-pct-${outputCount}.json`;
+            let fileOutPath = path.join(output, fileName);
+            
+            parser(path.join(input, file.name)).then((result) => {
+                fs.writeFile(fileOutPath, result, (err) => {
+                    if (err) { 
+                        throw new Error(err);
+                    }
+                });
+            });
+
+            outputCount++;
+        })
+    })
+};
+
+const main = async (input = DEFAULT_INPUT_DIR, output = DEFAULT_OUTPUT_DIR) => {
+    try {
+        bulkParse(input, output);
+    } catch (err) {
+        console.error("ERROR BULK PARSING... NOT OK")
+        console.error(err);
+    }
+}
+
+main(process.argv[2])

--- a/scripts/parse-json.js
+++ b/scripts/parse-json.js
@@ -43,17 +43,17 @@ const processAnalysis = (node) => {
 const processSequence = (node) => {
   if (!node.children) return node
 
-  const original = [];
+  const text = [];
 
   const analysis = processAnalysis(node)
 
-  const text = node.children.map((child) => {
+  const original = node.children.map((child) => {
     if (child.name === 'q') {
       return processQuote(child)
     }
 
     if (child.name === 'w') {
-      original.push(child.attr.canon)
+      text.push(child.attr.canon)
       return child.val
     }
     if (child.text) return child.text.replaceAll('\n', '')
@@ -61,7 +61,7 @@ const processSequence = (node) => {
     return null
   })
 
-  const processedText = processText(text)
+  const processedText = processText(original)
 
   const english = node.children.map((child) => {
     if (child.name === 'gloss') return child.val
@@ -75,7 +75,7 @@ const processSequence = (node) => {
 
   // only return footnote if it exists
 
-  const returnSeq = { original: processedText, text: original.join(' '), english, analysis }
+  const returnSeq = { original: processedText, text: text.join(' '), english, analysis }
 
   return footnote !== undefined ? { ...returnSeq, footnote } : returnSeq
 }

--- a/scripts/parse-json.js
+++ b/scripts/parse-json.js
@@ -143,7 +143,7 @@ const main = async (infile) => {
   // Uncomment this line for easier debugging in the console.
   // console.log(util.inspect(children, {depth: null}))
 
-  console.log(JSON.stringify(children))
+  return JSON.stringify(children)
 }
 
-main(process.argv[2])
+module.exports = main;

--- a/scripts/parse-json.js
+++ b/scripts/parse-json.js
@@ -43,6 +43,8 @@ const processAnalysis = (node) => {
 const processSequence = (node) => {
   if (!node.children) return node
 
+  const original = [];
+
   const analysis = processAnalysis(node)
 
   const text = node.children.map((child) => {
@@ -50,9 +52,10 @@ const processSequence = (node) => {
       return processQuote(child)
     }
 
-    //This is where we need to replace or get rid of \r, but it doesn't seem to accept a replace all. 
-
-    if (child.name === 'w') return child.val
+    if (child.name === 'w') {
+      original.push(child.attr.canon)
+      return child.val
+    }
     if (child.text) return child.text.replaceAll('\n', '')
 
     return null
@@ -72,7 +75,7 @@ const processSequence = (node) => {
 
   // only return footnote if it exists
 
-  const returnSeq = { text: processedText, english, analysis }
+  const returnSeq = { original: processedText, text: original.join(' '), english, analysis }
 
   return footnote !== undefined ? { ...returnSeq, footnote } : returnSeq
 }
@@ -87,6 +90,7 @@ const processChildren = (node) => {
       const transformedSentence = sentences.filter((token) => token)
 
       transformedSentence.forEach((sentence) => {
+        sentence.original = stripSentence(sentence.original)
         sentence.text = stripSentence(sentence.text)
       })
 


### PR DESCRIPTION
This is a simple PR that adjusts our original script to `return` a data string rather than `console.log()` it.

The larger file addition is the new script itself, which quickly parses through all of the existing `xml` files in the `source/PCT` directory. 

By default, `DEFAULT_INPUT_DIR` and `DEFAULT_OUTPUT_DIR` will be used. These can both be adjusted via executing the script by command line for different debugging purposes. 

Executing this script from the command line without these arguments will check if the `output` dir exists, create it if it doesn't, or empty it if it does, and then continue to fill it with the results of our `parse-json` script.

Closes #9 